### PR TITLE
fix inconsistences between propagated and unchanged

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ any given point in time to 5,
 
 [source,java]
 ----
-  @Inject @ManagedExecutorConfig(context=ThreadContext.CDI, maxAsync=5)
+  @Inject @ManagedExecutorConfig(propagated=ThreadContext.CDI, maxAsync=5)
   ManagedExecutor executor;
 ----
 

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * <p>Configures an injected <code>ManagedExecutor</code> instance.</p>
  *
  * <p>Example usage:</p>
- * <pre><code> &commat;Inject &commat;ManagedExecutorConfig(context=ThreadContext.CDI, maxAsync=5)
+ * <pre><code> &commat;Inject &commat;ManagedExecutorConfig(propagated=ThreadContext.CDI, maxAsync=5)
  * ManagedExecutor executor;
  * ...
  * </code></pre>
@@ -53,10 +53,10 @@ public @interface ManagedExecutorConfig {
      * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>Thread context types which are not otherwise included in this set
-     * are removed from the thread of execution for the duration of the
+     * are cleared from the thread of execution for the duration of the
      * action or task.</p>
      */
-    String[] context() default { ThreadContext.APPLICATION, ThreadContext.CDI, ThreadContext.SECURITY };
+    String[] propagated() default { ThreadContext.APPLICATION, ThreadContext.CDI, ThreadContext.SECURITY };
 
     /**
      * <p>Establishes an upper bound on the number of async completion stage

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -48,9 +48,7 @@ public interface ThreadContext {
      * Identifier for all available thread context types that support capture
      * and propagation to other threads.
      * 
-     * TODO Must not be used on 'unchanged' context, belongs on that JavaDoc.
-     *
-     * @see ManagedExecutorConfig#context
+     * @see ManagedExecutorConfig#propagated
      * @see ThreadContextConfig#value
      */
     static final String ALL = "All";
@@ -63,7 +61,7 @@ public interface ThreadContext {
      * application context means that the thread is not associated with any
      * application.
      *
-     * @see ManagedExecutorConfig#context
+     * @see ManagedExecutorConfig#propagated
      * @see ThreadContextConfig
      */
     static final String APPLICATION = "Application";
@@ -74,7 +72,7 @@ public interface ThreadContext {
      * access to the scope of the session, request, and so forth that created the
      * contextualized action.
      *
-     * @see ManagedExecutorConfig#context
+     * @see ManagedExecutorConfig#propagated
      * @see ThreadContextConfig
      */
     static final String CDI = "CDI";
@@ -84,7 +82,7 @@ public interface ThreadContext {
      * that are associated with the thread. An empty/default security context
      * means that the thread is unauthenticated.
      * 
-     * @see ManagedExecutorConfig#context
+     * @see ManagedExecutorConfig#propagated
      * @see ThreadContextConfig
      */
     static final String SECURITY = "Security";

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -53,7 +53,7 @@ public @interface ThreadContextConfig {
      * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>Thread context types which are not otherwise included in this set or
-     * in the {@link #unchanged} set are removed from the thread of execution
+     * in the {@link #unchanged} set are cleared from the thread of execution
      * for the duration of the action or task.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject if the same context
@@ -66,6 +66,14 @@ public @interface ThreadContextConfig {
      * <p>Defines a set of thread context types that are essentially ignored,
      * in that they are neither captured nor are they propagated or cleared
      * from thread(s) that execute the action or task.</p>
+     *
+     * <p>Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification. A <code>ThreadContext</code> must fail to
+     * inject if {@link ThreadContext#ALL} is included in the
+     * <code>unchanged</code> context because it would otherwise render the
+     * <code>ThreadContext</code> instance meaningless.</p>
      *
      * <p>The configuration <code>unchanged</code> context is provided for
      * advanced patterns where it is desirable to leave certain context types
@@ -84,10 +92,9 @@ public @interface ThreadContextConfig {
      * tx.commit();
      * </code></pre>
      *
-     * <p>Inclusion in this set of a thread context type which is a
-     * prerequisite of other thread context types implies that these other
-     * dependent types of context are 'unchanged' as well, even if not
-     * explicitly specified.</p>
+     * <p>Inclusion of a thread context type with prerequisites implies
+     * inclusion of the prerequisites, in that the prequisistes are
+     * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject if the same context
      * type is included in this set as well as in the set specified by

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -71,7 +71,8 @@ public @interface ThreadContextConfig {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification. A <code>ThreadContext</code> must fail to
-     * inject if {@link ThreadContext#ALL} is included in the
+     * inject, raising <code>DefinitionException</code> on application startup,
+     * if {@link ThreadContext#ALL} is included in the
      * <code>unchanged</code> context because it would otherwise render the
      * <code>ThreadContext</code> instance meaningless.</p>
      *


### PR DESCRIPTION
pull fixes #12

Renamed `context` on ManagedExecutorConfig to `propagated` in order to match the tense of `unchanged` and to be consistent with ThreadContextBuilder.  Updated docs accordingly.
Corrected explanation for implied prereqs for `unchanged` to match that of `propagated`.
Also removed a TODO from ThreadContext.ALL JavaDoc after placing the appropriate text in the `unchanged` JavaDoc which the TODO referred to. 

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>