### PR TITLE
clarify error conditions for #18

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
@@ -93,8 +93,10 @@ public interface ManagedExecutorBuilder {
     /**
      * <p>Establishes an upper bound on the number of async completion stage
      * actions and async executor tasks that can be running at any given point
-     * in time. Async actions and tasks remain queued until capacity is available
-     * to execute them.</p>
+     * in time. There is no guarantee that async actions or tasks will start
+     * running immediately, even when the <code>maxAsync</code> constraint has
+     * not get been reached. Async actions and tasks remain queued until
+     * the <code>ManagedExecutor</code> starts executing them.</p>
      *
      * <p>The default value of <code>-1</code> indicates no upper bound,
      * although practically, resource constraints of the system will apply.</p>

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
@@ -44,6 +44,12 @@ public interface ManagedExecutorBuilder {
      * instances.</p>
      *
      * @return new instance of <code>ManagedExecutor</code>.
+     * @throws IllegalStateException if the direct or indirect
+     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
+     *         of a <code>ThreadContextProvider</code> are unsatisfied,
+     *         or a provider has itself as a direct or indirect prerequisite,
+     *         or if more than one provider provides the same thread context
+     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
      */
     ManagedExecutor build();
 

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -70,8 +70,10 @@ public @interface ManagedExecutorConfig {
     /**
      * <p>Establishes an upper bound on the number of async completion stage
      * actions and async executor tasks that can be running at any given point
-     * in time. Async actions and tasks remain queued until capacity is available
-     * to execute them.</p>
+     * in time. There is no guarantee that async actions or tasks will start
+     * running immediately, even when the <code>maxAsync</code> constraint has
+     * not get been reached. Async actions and tasks remain queued until
+     * the <code>ManagedExecutor</code> starts executing them.</p>
      *
      * <p>The default value of <code>-1</code> indicates no upper bound,
      * although practically, resource constraints of the system will apply.</p>

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -32,6 +32,15 @@ import java.lang.annotation.Target;
  * ManagedExecutor executor;
  * ...
  * </code></pre>
+ *
+ * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+ * <code>DeploymentException</code> on application startup,
+ * if the direct or indirect
+ * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
+ * of a <code>ThreadContextProvider</code> are unsatisfied,
+ * or a provider has itself as a direct or indirect prerequisite,
+ * or if more than one provider provides the same thread context
+ * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
  */
 @Retention(RUNTIME)
 @Target(FIELD)
@@ -66,6 +75,10 @@ public @interface ManagedExecutorConfig {
      *
      * <p>The default value of <code>-1</code> indicates no upper bound,
      * although practically, resource constraints of the system will apply.</p>
+     *
+     * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+     * <code>DefinitionException</code> on application startup, if the
+     * <code>maxAsync</code> value is 0 or less than -1.
      */
     int maxAsync() default -1;
 
@@ -76,6 +89,10 @@ public @interface ManagedExecutorConfig {
      *
      * <p>The default value of <code>-1</code> indicates no upper bound,
      * although practically, resource constraints of the system will apply.</p>
+     *
+     * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+     * <code>DefinitionException</code> on application startup, if the
+     * <code>maxQueued</code> value is 0 or less than -1.
      */
     int maxQueued() default -1;
 }

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
@@ -46,6 +46,13 @@ public interface ThreadContextBuilder {
      * @throws IllegalArgumentException if the same thread context type is
      *         present in, or inferred by, both the {@link #propagated} set
      *         and the {@link #unchanged} set.
+     * @throws IllegalStateException if the direct or indirect
+     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
+     *         of a <code>ThreadContextProvider</code> are unsatisfied,
+     *         or if a <code>ThreadContextProvider</code> has a direct or
+     *         indirect prerequisite on itself, or if more than one
+     *         <code>ThreadContextProvider</code> has the same thread context
+     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
      */
     ThreadContext build();
 
@@ -81,9 +88,9 @@ public interface ThreadContextBuilder {
      * in the {@link #unchanged} set are cleared from the thread of execution
      * for the duration of the action or task.</p>
      *
-     * <p>A <code>ThreadContext</code> must fail to inject if the same context
-     * type is included in this set as well as in the {@link #unchanged} set.
-     * </p>
+     * <p>A <code>ThreadContext</code> must fail to {@link #build} if the same
+     * context type is included in this set as well as in the {@link #unchanged}
+     * set.</p>
      *
      * @param types types of thread context to capture and propagated.
      * @return the same builder instance upon which this method is invoked.
@@ -125,8 +132,8 @@ public interface ThreadContextBuilder {
      * inclusion of the prerequisites, in that the prequisistes are
      * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
-     * <p>A <code>ThreadContext</code> must fail to inject if the same context
-     * type is included in this set as well as in the set specified by
+     * <p>A <code>ThreadContext</code> must fail to {@link #build} if the same
+     * context type is included in this set as well as in the set specified by
      * {@link #propagated}.</p>
      *
      * @param types types of thread context to leave unchanged on the thread.

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -32,6 +32,15 @@ import java.lang.annotation.Target;
  * ThreadContext threadContext;
  * ...
  * </code></pre>
+ *
+ * <p>A <code>ThreadContext</code> must fail to inject, raising
+ * <code>DeploymentException</code> on application startup,
+ * if the direct or indirect
+ * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
+ * of a <code>ThreadContextProvider</code> are unsatisfied,
+ * or a provider has itself as a direct or indirect prerequisite,
+ * or if more than one provider provides the same thread context
+ * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
  */
 @Retention(RUNTIME)
 @Target(FIELD)
@@ -56,9 +65,10 @@ public @interface ThreadContextConfig {
      * in the {@link #unchanged} set are cleared from the thread of execution
      * for the duration of the action or task.</p>
      *
-     * <p>A <code>ThreadContext</code> must fail to inject if the same context
-     * type is included in this set as well as in the {@link #unchanged} set.
-     * </p>
+     * <p>A <code>ThreadContext</code> must fail to inject, raising
+     * <code>DefinitionException</code> on application startup, if the same
+     * context type is included in this set as well as in the {@link #unchanged}
+     * set.</p>
      */
     String[] value() default { ThreadContext.APPLICATION, ThreadContext.CDI, ThreadContext.SECURITY };
 
@@ -70,11 +80,7 @@ public @interface ThreadContextConfig {
      * <p>Constants for specifying some of the core context types are provided
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
-     * MicroProfile specification. A <code>ThreadContext</code> must fail to
-     * inject, raising <code>DefinitionException</code> on application startup,
-     * if {@link ThreadContext#ALL} is included in the
-     * <code>unchanged</code> context because it would otherwise render the
-     * <code>ThreadContext</code> instance meaningless.</p>
+     * MicroProfile specification.
      *
      * <p>The configuration <code>unchanged</code> context is provided for
      * advanced patterns where it is desirable to leave certain context types
@@ -97,9 +103,13 @@ public @interface ThreadContextConfig {
      * inclusion of the prerequisites, in that the prequisistes are
      * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
-     * <p>A <code>ThreadContext</code> must fail to inject if the same context
-     * type is included in this set as well as in the set specified by
-     * {@link ThreadContextConfig#value}.</p>
+     * <p>A <code>ThreadContext</code> must fail to inject, raising
+     * <code>DefinitionException</code> on application startup, if the same
+     * context type is included in this set as well as in the set specified by
+     * {@link ThreadContextConfig#value}, or if {@link ThreadContext#ALL} is
+     * included in the <code>unchanged</code> context because the latter would
+     * otherwise render the <code>ThreadContext</code> instance meaningless.
+     * </p>
      */
     String[] unchanged() default {};
 }


### PR DESCRIPTION
pull fixes #18

Add clarification for error conditions, being consistent between CDI annotative config versus builder config.

For error conditions with thread context providers, this uses IllegalStateException for builders and DeploymentException for CDI.
For configuration errors made by the application, this uses IllegalArgumentException for builders and DefinitionException for CDI.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>