### PR TITLE
Support per-classloader configuration and specify when to load the ThreadContextProviders

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ConcurrencyManager.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ConcurrencyManager.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrent.spi;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
+import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
+
+/**
+ * {@link ConcurrencyManager} instances can be used to create {@link #newManagedExecutorBuilder()}
+ * or {@link #newThreadContextBuilder()}. Each {@link ConcurrencyManager} instance has its own set
+ * of {@link ThreadContextProvider} as defined during building with {@link ConcurrencyManagerBuilder#build()}
+ * or {@link ConcurrencyProvider#getConcurrencyManager()}.
+ *
+ * @see ConcurrencyProvider#getConcurrencyManager()
+ * @see ConcurrencyManagerBuilder
+ */
+public interface ConcurrencyManager {
+    /**
+     * Creates a new <code>ManagedExecutorBuilder</code> instance.
+     *
+     * @return a new <code>ManagedExecutorBuilder</code> instance.
+     */
+    ManagedExecutorBuilder newManagedExecutorBuilder();
+
+    /**
+     * Creates a new <code>ThreadContextBuilder</code> instance.
+     *
+     * @return a new <code>ThreadContextBuilder</code> instance.
+     */
+    ThreadContextBuilder newThreadContextBuilder(); 
+
+}

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ConcurrencyManagerBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ConcurrencyManagerBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrent.spi;
+
+/**
+ * Use this class to configure instances of {@link ConcurrencyManager}.
+ */
+public interface ConcurrencyManagerBuilder {
+    
+    /**
+     * Use the specified {@link ThreadContextProvider} instances.
+     * @param providers the {@link ThreadContextProvider} instances to use.
+     * @return this builder
+     */
+    public ConcurrencyManagerBuilder withThreadContextProviders(ThreadContextProvider... providers);
+
+    /**
+     * Load all discoverable {@link ThreadContextProvider} instances via the {@link ServiceLoader}
+     * mechanism on the current thread-context {@link ClassLoader} (unless overridden by {@link #forClassLoader(ClassLoader)}).
+     * 
+     * @return this builder
+     */
+    public ConcurrencyManagerBuilder addDiscoveredThreadContextProviders();
+
+    /**
+     * Use the given {@link ClassLoader} for {@link #addDiscoveredThreadContextProviders()} instead
+     * of the current thread-context {@link ClassLoader}.
+     * 
+     * @param classLoader the {@link ClassLoader} to use for {@link #addDiscoveredThreadContextProviders()}
+     * @return this builder
+     */
+    public ConcurrencyManagerBuilder forClassLoader(ClassLoader classLoader);
+    
+    /**
+     * Creates a new {@link ConcurrencyManager} with the specified configuration.
+     * @return a new {@link ConcurrencyManager} with the specified configuration.
+     */
+    public ConcurrencyManager build();
+}


### PR DESCRIPTION
I've finally been able to reproduce the issues related to having multiple sets of `ThreadContextProvider` and `ThreadContextPropagator` in separate applications (different wars with different context classloaders), in a container which provides MP-Concurrency (in a parent classloader).

The proposed fix is to copy the MP-Config configuration by introducing the concept of `ConcurrencyManager` which is the object we get/create out of the `ConcurrencyProvider`, whose role is to load all the sets of `ThreadContextProvider` and `ThreadContextPropagator` (not in this PR) for a given `ClassLoader`. A `ConcurrencyManager` will therefore have its own set of providers and be able to create new `ThreadContextBuilder` and `ManagedExecutorBuilder` instances for those providers.

Using `ConcurrencyProvider.getConcurrencyManager()` will lazily create (and memoize) a `ConcurrencyManager` for the current thread-context `ClassLoader`, which should work for most application types. Containers which can unload applications can call `ConcurrencyProvider.unregisterConcurrencyManager` to clear the cache. 

Additionally we now have a `ConcurrencyManagerBuilder` that lets us manually specify if the `ThreadContextProvider` should be service-loaded or manually loaded, and which `ClassLoader` to use.

Again, all this is copied from MP-Config, and there's a good reason it all went in there. I have an implementation of this all in SmallRye Concurrency which validates that these additions solve all the concerns I had regarding multiple applications, and will allow me to close several related issues such as #5 and #7.