### PR TITLE
name collision on withCurrentContext when using lambdas

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,7 +120,7 @@ ThreadContext via the `@Inject` annotation, for example:
       .supplyAsync(supplier1)
       .thenApplyAsync(function1)
       .thenApply(function2)
-      .thenApply(threadContext.withCurrentContext(function3));
+      .thenApply(threadContext.contextualFunction(function3));
 ----
 
 The container provides default instances of ManagedExecutor and

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -42,14 +42,14 @@ import java.util.function.Supplier;
  *
  * <p>This specification allows for managed executors that do not capture and propagate thread context,
  * which can offer better performance. If thread context propagation is desired only for specific stages,
- * the <code>ThreadContext.withCurrentContext</code> API can be used to propagate thread context to
+ * the <code>ThreadContext.contextual*</code> API methods can be used to propagate thread context to
  * individual actions.</p>
  *
  * <p>Example of single action with context propagation:</p>
  * <pre>
  * CompletableFuture&lt;?&gt; future = executor
  *    .runAsync(runnable1)
- *    .thenRun(threadContext.withCurrentContext(runnable2))
+ *    .thenRun(threadContext.contextualRunnable(runnable2))
  *    .thenRunAsync(runnable3)
  *    ...
  * </pre>

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
@@ -156,7 +156,7 @@ public interface ThreadContextBuilder {
      *                                                   .propagated(ThreadContext.ALL_REMAINING)
      *                                                   .build();
      * ...
-     * task = threadContext.withCurrentContext(new MyTransactionlTask());
+     * task = threadContext.contextualRunnable(new MyTransactionlTask());
      * ...
      * // on another thread,
      * tx.begin();

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -124,7 +124,7 @@ public @interface ThreadContextConfig {
      *                              cleared = ThreadContext.ALL_REMAINING)
      * ThreadContext threadContext;
      * ...
-     * task = threadContext.withCurrentContext(new MyTransactionalTask());
+     * task = threadContext.contextualRunnable(new MyTransactionalTask());
      * ...
      * // on another thread,
      * tx.begin();


### PR DESCRIPTION
Pull fixes #32 

Renamed withCurrentContext to the following depending on which type is being contextualized,
contextualCallable
contextualConsumer
contextualFunction
contextualRunnable
contextualSupplier

This eliminates the ambiguity and makes it possible to use lambdas without the workaround of casting them to clarify the type.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>