### PR TITLE
fix javadoc to remove prerequisite context

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -176,6 +176,5 @@ With this model, the provider of thread context implements the
 org.eclipse.microprofile.concurrent.spi.ThreadContextProvider
 interface and packages it in a way that makes it available to the
 ServiceLoader. ThreadContextProvider identifies the thread context
-type and any prerequisite thread context types that it has,
-and it allows for capturing snapshots of thread context
-as well as for applying empty/default context to threads.
+type and provides a way to capture snapshots of thread context
+as well as for applying empty/cleared context to threads.

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
@@ -50,11 +50,6 @@ public interface ManagedExecutorBuilder {
      *         {@link #cleared} set and the {@link #propagated} set</li>
      *         <li>if a thread context type that is configured to be
      *         {@link #cleared} or {@link #propagated} is unavailable</li>
-     *         <li>if the direct or indirect
-     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
-     *         of a <code>ThreadContextProvider</code> are unsatisfied</li>
-     *         <li>if a <code>ThreadContextProvider</code> has a direct or
-     *         indirect prerequisite on itself</li>
      *         <li>if more than one provider provides the same thread context
      *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}
      *         </li>
@@ -80,9 +75,6 @@ public interface ManagedExecutorBuilder {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * @param types types of thread context to clear from threads that run
      *        actions and tasks.
@@ -110,9 +102,6 @@ public interface ManagedExecutorBuilder {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>Thread context types which are not otherwise included in this set
      * are cleared from the thread of execution for the duration of the

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -35,11 +35,7 @@ import java.lang.annotation.Target;
  *
  * <p>A <code>ManagedExecutor</code> must fail to inject, raising
  * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
- * on application startup, if the direct or indirect
- * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
- * of a <code>ThreadContextProvider</code> are unsatisfied,
- * or a provider has itself as a direct or indirect prerequisite,
- * or if more than one provider provides the same thread context
+ * on application startup, if more than one provider provides the same thread context
  * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
  */
 @Retention(RUNTIME)
@@ -59,9 +55,6 @@ public @interface ManagedExecutorConfig {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
      * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
@@ -89,9 +82,6 @@ public @interface ManagedExecutorConfig {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>Thread context types which are not otherwise included in this set
      * are cleared from the thread of execution for the duration of the

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
@@ -50,11 +50,6 @@ public interface ThreadContextBuilder {
      *         ({@link #cleared}, {@link #propagated}, {@link #unchanged})</li>
      *         <li>if a thread context type that is configured to be
      *         {@link #cleared} or {@link #propagated} is unavailable</li>
-     *         <li>if the direct or indirect
-     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
-     *         of a <code>ThreadContextProvider</code> are unsatisfied</li>
-     *         <li>if a <code>ThreadContextProvider</code> has a direct or
-     *         indirect prerequisite on itself</li>
      *         <li>if more than one <code>ThreadContextProvider</code> has the
      *         same thread context
      *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}
@@ -91,9 +86,6 @@ public interface ThreadContextBuilder {
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
      *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
-     *
      * @param types types of thread context to clear from threads that run
      *        actions and tasks.
      * @return the same builder instance upon which this method is invoked.
@@ -120,9 +112,6 @@ public interface ThreadContextBuilder {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>Thread context types which are not otherwise included in this set or
      * in the {@link #unchanged} set are cleared from the thread of execution
@@ -170,10 +159,6 @@ public interface ThreadContextBuilder {
      * task.run(); // runs under the transaction due to 'unchanged'
      * tx.commit();
      * </code></pre>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, in that the prequisistes are
-     * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to {@link #build} if the same
      * context type is included in this set as well as in the set specified by

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -35,12 +35,7 @@ import java.lang.annotation.Target;
  *
  * <p>A <code>ThreadContext</code> must fail to inject, raising
  * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
- * on application startup,
- * if the direct or indirect
- * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
- * of a <code>ThreadContextProvider</code> are unsatisfied,
- * or a provider has itself as a direct or indirect prerequisite,
- * or if more than one provider provides the same thread context
+ * on application startup, if more than one provider provides the same thread context
  * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
  */
 @Retention(RUNTIME)
@@ -60,9 +55,6 @@ public @interface ThreadContextConfig {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
      * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
@@ -90,9 +82,6 @@ public @interface ThreadContextConfig {
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related
      * MicroProfile specification.</p>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>Thread context types which are not otherwise included in this set or
      * in the {@link #unchanged} set are cleared from the thread of execution
@@ -136,10 +125,6 @@ public @interface ThreadContextConfig {
      * task.run(); // runs under the transaction due to 'unchanged'
      * tx.commit();
      * </code></pre>
-     *
-     * <p>Inclusion of a thread context type with prerequisites implies
-     * inclusion of the prerequisites, in that the prequisistes are
-     * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
      * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ThreadContextProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ThreadContextProvider.java
@@ -18,9 +18,7 @@
  */
 package org.eclipse.microprofile.concurrent.spi;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * <p>Third party providers of thread context implement this interface to enable the
@@ -90,32 +88,6 @@ public interface ThreadContextProvider {
      * @return immutable empty/default context of the provided type.
      */
     ThreadContextSnapshot clearedContext(Map<String, String> props);
-
-    /**
-     * <p>Returns an immutable set of thread context type identifiers (refer to
-     * <code>getThreadContextType</code>) that the provided type of thread context
-     * depends upon.</p>
-     *
-     * <p>The <code>ManagedExecutor</code> and <code>ThreadContext</code> implementation
-     * must ensure that all prerequisite types are established on the thread
-     * before invoking the <code>ThreadContextSnapshot.begin</code> method for this type
-     * of thread context and must also ensure that the prerequisite types are not removed
-     * until after the corresponding <code>ThreadContextController.endContext</code> method.</p>
-     *
-     * <p>This has the effect of guaranteeing that prerequisite context types are available
-     * for the duration of the contextualized action/task as well as during the initial
-     * establishment and subsequent removal of thread context.</p>
-     *
-     * <p>The default implementation of this method returns <code>Collections.EMPTY_SET</code>,
-     * indicating that this context type has no prerequisites.</p>
-     *
-     * @return immutable set of identifiers for prerequisite thread context types.
-     *         Thread context providers that have no prerequisites must return
-     *         <code>Collections.EMPTY_SET</code> to indicate this.
-     */
-    default Set<String> getPrerequisites() {
-        return Collections.EMPTY_SET;
-    }
 
     /**
      * <p>Returns a human readable identifier for the type of thread context that is


### PR DESCRIPTION
pull fixes #34

Update JavaDoc for prerequisites to clarify that when providers declare context types as prerequisite, this helps determine the order in which context types are applied to the execution thread, but it does not create implicit propagation/clearing/unchanging of the prereq types when the thread context type that declares them prerequisite is configured to propagate/clear/remain unchanged.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>