### PR TITLE
require build/inject to fail when user configures an unavailable context type

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
@@ -44,9 +44,11 @@ public interface ManagedExecutorBuilder {
      * instances.</p>
      *
      * @return new instance of <code>ManagedExecutor</code>.
-     * @throws IllegalArgumentException if the same thread context type is
-     *         present in, or inferred by, both the {@link #cleared} set
-     *         and the {@link #propagated} set.
+     * @throws IllegalArgumentException if a thread context type that is
+     *         configured to be {@link #cleared} or {@link #propagated} is
+     *         unavailable. Also raises IllegalArgumentException if one or
+     *         more of the same context types appear in both the
+     *         {@link #cleared} set and the {@link #propagated} set.
      * @throws IllegalStateException if the direct or indirect
      *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
      *         of a <code>ThreadContextProvider</code> are unsatisfied,

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorBuilder.java
@@ -44,17 +44,21 @@ public interface ManagedExecutorBuilder {
      * instances.</p>
      *
      * @return new instance of <code>ManagedExecutor</code>.
-     * @throws IllegalArgumentException if a thread context type that is
-     *         configured to be {@link #cleared} or {@link #propagated} is
-     *         unavailable. Also raises IllegalArgumentException if one or
-     *         more of the same context types appear in both the
-     *         {@link #cleared} set and the {@link #propagated} set.
-     * @throws IllegalStateException if the direct or indirect
+     * @throws IllegalStateException for any of the following error conditions
+     *         <ul>
+     *         <li>if one or more of the same context types appear in both the
+     *         {@link #cleared} set and the {@link #propagated} set</li>
+     *         <li>if a thread context type that is configured to be
+     *         {@link #cleared} or {@link #propagated} is unavailable</li>
+     *         <li>if the direct or indirect
      *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
-     *         of a <code>ThreadContextProvider</code> are unsatisfied,
-     *         or a provider has itself as a direct or indirect prerequisite,
-     *         or if more than one provider provides the same thread context
-     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
+     *         of a <code>ThreadContextProvider</code> are unsatisfied</li>
+     *         <li>if a <code>ThreadContextProvider</code> has a direct or
+     *         indirect prerequisite on itself</li>
+     *         <li>if more than one provider provides the same thread context
+     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}
+     *         </li>
+     *         </ul>
      */
     ManagedExecutor build();
 

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -64,9 +64,10 @@ public @interface ManagedExecutorConfig {
      * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the same
-     * context type is implicitly or explicitly included in this set
-     * as well as in the set specified by {@link #propagated}.</p>
+     * <code>DefinitionException</code> on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #propagated} set includes one or more of the
+     * same types as this set.</p>
      */
     String[] cleared() default { ThreadContext.TRANSACTION };
 
@@ -96,9 +97,10 @@ public @interface ManagedExecutorConfig {
      * action or task.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the same
-     * context type is implicitly or explicitly included in this set
-     * as well as in the set specified by {@link #cleared}.</p>
+     * <code>DefinitionException</code> on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} set includes one or more of the
+     * same types as this set.</p>
      */
     String[] propagated() default { ThreadContext.ALL_REMAINING };
 

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -34,8 +34,8 @@ import java.lang.annotation.Target;
  * </code></pre>
  *
  * <p>A <code>ManagedExecutor</code> must fail to inject, raising
- * <code>DeploymentException</code> on application startup,
- * if the direct or indirect
+ * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
+ * on application startup, if the direct or indirect
  * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
  * of a <code>ThreadContextProvider</code> are unsatisfied,
  * or a provider has itself as a direct or indirect prerequisite,
@@ -64,7 +64,8 @@ public @interface ManagedExecutorConfig {
      * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup,
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
      * if a context type specified within this set is unavailable
      * or if the {@link #propagated} set includes one or more of the
      * same types as this set.</p>
@@ -97,7 +98,8 @@ public @interface ManagedExecutorConfig {
      * action or task.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup,
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
      * if a context type specified within this set is unavailable
      * or if the {@link #cleared} set includes one or more of the
      * same types as this set.</p>
@@ -116,7 +118,8 @@ public @interface ManagedExecutorConfig {
      * although practically, resource constraints of the system will apply.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup, if the
      * <code>maxAsync</code> value is 0 or less than -1.
      */
     int maxAsync() default -1;
@@ -130,7 +133,8 @@ public @interface ManagedExecutorConfig {
      * although practically, resource constraints of the system will apply.</p>
      *
      * <p>A <code>ManagedExecutor</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup, if the
      * <code>maxQueued</code> value is 0 or less than -1.
      */
     int maxQueued() default -1;

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
@@ -43,9 +43,11 @@ public interface ThreadContextBuilder {
      * instances.</p>
      *
      * @return new instance of <code>ThreadContext</code>.
-     * @throws IllegalArgumentException if the same thread context type is
-     *         present in, or inferred by, more than one of the
-     *         following categories:
+     * @throws IllegalArgumentException if a thread context type that is
+     *         configured to be {@link #cleared} or {@link #propagated} is
+     *         unavailable. Also raises IllegalArgumentException if one or
+     *         more of the same context types appear in multiple of the
+     *         following sets:
      *         ({@link #cleared}, {@link #propagated}, {@link #unchanged}).
      * @throws IllegalStateException if the direct or indirect
      *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextBuilder.java
@@ -43,19 +43,23 @@ public interface ThreadContextBuilder {
      * instances.</p>
      *
      * @return new instance of <code>ThreadContext</code>.
-     * @throws IllegalArgumentException if a thread context type that is
-     *         configured to be {@link #cleared} or {@link #propagated} is
-     *         unavailable. Also raises IllegalArgumentException if one or
-     *         more of the same context types appear in multiple of the
-     *         following sets:
-     *         ({@link #cleared}, {@link #propagated}, {@link #unchanged}).
-     * @throws IllegalStateException if the direct or indirect
+     * @throws IllegalStateException for any of the following error conditions
+     *         <ul>
+     *         <li>if one or more of the same context types appear in multiple
+     *         of the following sets:
+     *         ({@link #cleared}, {@link #propagated}, {@link #unchanged})</li>
+     *         <li>if a thread context type that is configured to be
+     *         {@link #cleared} or {@link #propagated} is unavailable</li>
+     *         <li>if the direct or indirect
      *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
-     *         of a <code>ThreadContextProvider</code> are unsatisfied,
-     *         or if a <code>ThreadContextProvider</code> has a direct or
-     *         indirect prerequisite on itself, or if more than one
-     *         <code>ThreadContextProvider</code> has the same thread context
-     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
+     *         of a <code>ThreadContextProvider</code> are unsatisfied</li>
+     *         <li>if a <code>ThreadContextProvider</code> has a direct or
+     *         indirect prerequisite on itself</li>
+     *         <li>if more than one <code>ThreadContextProvider</code> has the
+     *         same thread context
+     *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}
+     *         </li>
+     *         </ul>
      */
     ThreadContext build();
 

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -64,10 +64,10 @@ public @interface ThreadContextConfig {
      * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the same
-     * context type is implicitly or explicitly included in this set
-     * as well as in the set specified by {@link #propagated}
-     * or the set specified by {@link #unchanged}.</p>
+     * <code>DefinitionException</code> on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #value propagated} and/or {@link #unchanged} set
+     * includes one or more of the same types as this set.</p>
      */
     String[] cleared() default { ThreadContext.TRANSACTION };
 
@@ -97,9 +97,10 @@ public @interface ThreadContextConfig {
      * for the duration of the action or task.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the same
-     * context type is included in this set as well as in the {@link #cleared}
-     * set or the {@link #unchanged} set.</p>
+     * <code>DefinitionException</code> on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} and/or {@link #unchanged} set
+     * includes one or more of the same types as this set.</p>
      */
     String[] value() default { ThreadContext.ALL_REMAINING };
 
@@ -138,10 +139,10 @@ public @interface ThreadContextConfig {
      * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup, if the same
-     * context type is included in this set as well as in the set specified by
-     * {@link ThreadContextConfig#unchanged} or the set specified by
-     * {@link ThreadContextConfig#value}.</p>
+     * <code>DefinitionException</code> on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} and/or {@link #value propagated} set
+     * includes one or more of the same types as this set.</p>
      */
     String[] unchanged() default {};
 }

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -34,7 +34,8 @@ import java.lang.annotation.Target;
  * </code></pre>
  *
  * <p>A <code>ThreadContext</code> must fail to inject, raising
- * <code>DeploymentException</code> on application startup,
+ * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
+ * on application startup,
  * if the direct or indirect
  * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getPrerequisites prerequisites}
  * of a <code>ThreadContextProvider</code> are unsatisfied,
@@ -64,7 +65,8 @@ public @interface ThreadContextConfig {
      * inclusion of the prerequisites, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup,
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
      * if a context type specified within this set is unavailable
      * or if the {@link #value propagated} and/or {@link #unchanged} set
      * includes one or more of the same types as this set.</p>
@@ -97,7 +99,8 @@ public @interface ThreadContextConfig {
      * for the duration of the action or task.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup,
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
      * if a context type specified within this set is unavailable
      * or if the {@link #cleared} and/or {@link #unchanged} set
      * includes one or more of the same types as this set.</p>
@@ -139,7 +142,8 @@ public @interface ThreadContextConfig {
      * considered 'unchanged' as well, even if not explicitly specified.</p>
      *
      * <p>A <code>ThreadContext</code> must fail to inject, raising
-     * <code>DefinitionException</code> on application startup,
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
      * if a context type specified within this set is unavailable
      * or if the {@link #cleared} and/or {@link #value propagated} set
      * includes one or more of the same types as this set.</p>


### PR DESCRIPTION
As discussed in the issue that this fixes #24 , this pull updates JavaDoc to require that an error be raised on ManagedExecutorBuilder.build and ThreadContextBuilder.build when a specified type of thread context is not available.  And it similarly updates JavaDoc on ManagedExecutorConfig/ThreadContextConfig to similarly require that injection fail when a specified type of thread context is not available.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>