### PR TITLE
Clean up ConcurrencyProvider and clearly indicate which parts are optional

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -81,7 +81,7 @@ public interface ManagedExecutor extends ExecutorService {
      * @return a new {@link Builder} instance.
      */
     public static Builder builder() {
-        return ConcurrencyProvider.instance().newManagedExecutorBuilder();
+        return ConcurrencyProvider.instance().getConcurrencyManager().newManagedExecutorBuilder();
     }
 
     /**

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -55,7 +55,7 @@ public interface ThreadContext {
      * @return a new {@link Builder} instance.
      */
     public static Builder builder() {
-        return ConcurrencyProvider.instance().newThreadContextBuilder();
+        return ConcurrencyProvider.instance().getConcurrencyManager().newThreadContextBuilder();
     }
 
     /**

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ConcurrencyProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ConcurrencyProvider.java
@@ -106,6 +106,8 @@ public interface ConcurrencyProvider {
      * which is the default implementation of this method.
      * 
      * @return a {@link ConcurrencyManager} for the current thread-context {@link ClassLoader}.
+     * @throws IllegalStateException if more than one {@link ThreadContextProvider}
+     *         provides the same thread context {@link ThreadContextProvider#getThreadContextType type}
      * @see #getConcurrencyManager(ClassLoader)
      */
     public default ConcurrencyManager getConcurrencyManager() {
@@ -129,6 +131,8 @@ public interface ConcurrencyProvider {
      *
      * @param classloader the class loader for which to obtain the concurrency manager.
      * @return a {@link ConcurrencyManager} for the given {@link ClassLoader}.
+     * @throws IllegalStateException if more than one {@link ThreadContextProvider}
+     *         provides the same thread context {@link ThreadContextProvider#getThreadContextType type}
      * @see ConcurrencyManagerBuilder#addDiscoveredThreadContextProviders()
      * @see ConcurrencyManagerBuilder#build()
      * @see #registerConcurrencyManager(ConcurrencyManager, ClassLoader)


### PR DESCRIPTION
pull fixes #37 

Removed newManagedExecutorBuilder/newThreadContextBuilder methods from ConcurrencyProvider because they duplicate the same methods on ConcurrencyManager.

Provided default implementation of getConcurrencyManager() which does what the JavaDoc already says it does.

Add clarifying JavaDoc to ConcurrencyProvider indicating what is optional and defaulting these methods to raising UnsupportedOperationException.

As as result of all of this, it is now possible to implement ConcurrencyProvider by implementing a single method:
getConcurrencyManager(ClassLoader)
And optionally, to implement the following methods:
getConcurrencyManagerBuilder()
register/releaseConcurrencyManager(ConcurrencyManager)


Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>