### PR TITLE
fix ManagedExecutorConfig and ThreadContextConfig CDI qualifiers to be Dependent scoped and state when the same instance is returned

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * <p>Provides configuration for an injected {@link ManagedExecutor} instance
  * which is {@link javax.enterprise.context.Dependent dependent} scoped.
  * When an application has multiple injection points for {@link ManagedExecutor}
- * with matching configuration, the container must inject the same instance.
+ * with matching configuration, the container injects the same instance.
  * For the purposes of matching, array attributes of this annotation are
  * considered as unordered sets where duplicate elements are ignored.</p>
  *
@@ -41,9 +41,9 @@ import java.lang.annotation.Target;
  * ...
  * </code></pre>
  *
- * <p>A {@link ManagedExecutor}'s life cycle is tied to that of the application.
- * When the application stops, the container automatically shuts down the
- * managed executor and cancels its remaining actions/tasks.</p>
+ * <p>All created instances of {@link ManagedExecutor} are destroyed
+ * when the application is stopped. The container automatically shuts down these
+ * managed executors and cancels their remaining actions/tasks.</p>
  *
  * <p>A {@link ManagedExecutor} must fail to inject, raising
  * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -19,13 +19,21 @@
 package org.eclipse.microprofile.concurrent;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <p>Configures an injected <code>ManagedExecutor</code> instance.</p>
+ * <p>Provides configuration for an injected {@link ManagedExecutor} instance
+ * which is {@link javax.enterprise.context.Dependent dependent} scoped.
+ * When an application has multiple injection points for {@link ManagedExecutor}
+ * with matching configuration, the container must inject the same instance.
+ * For the purposes of matching, array attributes of this annotation are
+ * considered as unordered sets where duplicate elements are ignored.</p>
  *
  * <p>Example usage:</p>
  * <pre><code> &commat;Inject &commat;ManagedExecutorConfig(propagated=ThreadContext.CDI, maxAsync=5)
@@ -33,13 +41,17 @@ import java.lang.annotation.Target;
  * ...
  * </code></pre>
  *
- * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+ * <p>A {@link ManagedExecutor}'s life cycle is tied to that of the application.
+ * When the application stops, the container automatically shuts down the
+ * managed executor and cancels its remaining actions/tasks.</p>
+ *
+ * <p>A {@link ManagedExecutor} must fail to inject, raising
  * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
  * on application startup, if more than one provider provides the same thread context
  * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
  */
 @Retention(RUNTIME)
-@Target(FIELD)
+@Target({ FIELD, METHOD, PARAMETER, TYPE })
 public @interface ManagedExecutorConfig {
     /**
      * <p>Defines the set of thread context types to clear from the thread

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * <p>Provides configuration for an injected {@link ThreadContext} instance,
  * which is {@link javax.enterprise.context.Dependent dependent} scoped.
  * When an application has multiple injection points for {@link ThreadContext}
- * with matching configuration, the container must inject the same instance.
+ * with matching configuration, the container injects the same instance.
  * For the purposes of matching, array attributes of this annotation are
  * considered as unordered sets where duplicate elements are ignored.</p>
  *
@@ -41,9 +41,9 @@ import java.lang.annotation.Target;
  * ...
  * </code></pre>
  *
- * <p>A {@link ThreadContext} service's life cycle is tied to that of the application.
- * When the application stops, the container automatically shuts down the
- * {@link ThreadContext} service, cancels its remaining
+ * <p>All created instances of {@link ThreadContext} are destroyed
+ * when the application is stopped. The container automatically shuts down these
+ * {@link ThreadContext} instances, cancels their remaining
  * <code>CompletableFuture</code>s and <code>CompletionStage</code>s, and
  * and raises <code>IllegalStateException</code> to reject subsequent attempts
  * to apply previously captured thread context.</p>

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -19,13 +19,21 @@
 package org.eclipse.microprofile.concurrent;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <p>Configures an injected <code>ThreadContext</code> instance.</p>
+ * <p>Provides configuration for an injected {@link ThreadContext} instance,
+ * which is {@link javax.enterprise.context.Dependent dependent} scoped.
+ * When an application has multiple injection points for {@link ThreadContext}
+ * with matching configuration, the container must inject the same instance.
+ * For the purposes of matching, array attributes of this annotation are
+ * considered as unordered sets where duplicate elements are ignored.</p>
  *
  * <p>Example usage:</p>
  * <pre><code> &commat;Inject &commat;ThreadContextConfig(ThreadContext.CDI)
@@ -33,13 +41,20 @@ import java.lang.annotation.Target;
  * ...
  * </code></pre>
  *
+ * <p>A {@link ThreadContext} service's life cycle is tied to that of the application.
+ * When the application stops, the container automatically shuts down the
+ * {@link ThreadContext} service, cancels its remaining
+ * <code>CompletableFuture</code>s and <code>CompletionStage</code>s, and
+ * and raises <code>IllegalStateException</code> to reject subsequent attempts
+ * to apply previously captured thread context.</p>
+ *
  * <p>A <code>ThreadContext</code> must fail to inject, raising
  * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
  * on application startup, if more than one provider provides the same thread context
  * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
  */
 @Retention(RUNTIME)
-@Target(FIELD)
+@Target({ FIELD, METHOD, PARAMETER, TYPE })
 public @interface ThreadContextConfig {
     /**
      * <p>Defines the set of thread context types to clear from the thread


### PR DESCRIPTION
pull fixes #40

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>