### PR TITLE
allow shutdown for managed executors created by the application

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -70,9 +70,20 @@ import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
  * <p>This interface is intentionally kept compatible with ManagedExecutorService,
  * with the hope that its methods might one day be contributed to that specification.</p>
  *
- * <p>Managed executors are managed by the container, not be the user. Therefore, all
- * life cycle methods must raise IllegalStateException. This includes:
- * awaitTermination, isShutdown, isTerminated, shutdown, shutdownNow</p>
+ * <p>Managed executors that are created with the {@link Builder} or created for
+ * injection into applications via CDI must support the life cycle methods, including:
+ * awaitTermination, isShutdown, isTerminated, shutdown, shutdownNow.
+ * The application must invoke <code>shutdown</code> or <code>shutdownNow</code> to terminate
+ * the life cycle of each managed executor that it creates, once the managed executor is
+ * no longer needed. When the application stops, the container invokes <code>shutdownNow</code>
+ * for any remaining managed executors that the application did not already shut down.
+ * The shutdown methods signal the managed executor that it does not need to remain active to
+ * service subsequent requests and allow the container to properly clean up associated resources.</p>
+ *
+ * <p>Managed executors which have a life cycle that is scoped to the container,
+ * including those obtained via mechanisms defined by EE Concurrency, must raise
+ * IllegalStateException upon invocation of the aforementioned life cycle methods,
+ * in order to preserve compatibility with that specification.</p>
  */
 public interface ManagedExecutor extends ExecutorService {
     /**

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -418,9 +418,10 @@ public interface ThreadContext {
      * <p>Returns a new <code>CompletableFuture</code> that is completed by the completion of the
      * specified stage.</p>
      *
-     * <p>The container supplies the default asynchronous execution facility for the new completable
-     * future that is returned by this method and all dependent stages that are created from it,
-     * and all dependent stages that are created from those, and so forth.</p>
+     * <p>The new completable future is backed by a ThreadContext rather than a ManagedExecutor,
+     * and therefore its default asynchronous execution facility, which is supplied by the container,
+     * must run all dependent stages (and all dependent stages created from those, and so forth)
+     * inline rather than as separate asynchronous requests.</p>
      *
      * <p>When dependent stages are created from the new completable future, thread context is captured
      * from the thread that creates the dependent stage and is applied to the thread that runs the
@@ -444,9 +445,10 @@ public interface ThreadContext {
      * <p>Returns a new <code>CompletionStage</code> that is completed by the completion of the
      * specified stage.</p>
      *
-     * <p>The container supplies the default asynchronous execution facility for the new completion
-     * stage that is returned by this method and all dependent stages that are created from it,
-     * and all dependent stages that are created from those, and so forth.</p>
+     * <p>The new completion stage is backed by a ThreadContext rather than a ManagedExecutor,
+     * and therefore its default asynchronous execution facility, which is supplied by the container,
+     * must run all dependent stages (and all dependent stages created from those, and so forth)
+     * inline rather than as separate asynchronous requests.</p>
      *
      * <p>When dependent stages are created from the new completion stage, thread context is captured
      * from the thread that creates the dependent stage and is applied to the thread that runs the


### PR DESCRIPTION
Pull fixes #45

Allow shutdown for managed executors created by the application and move completion stage methods from ThreadContext to ManagedExecutor to make ThreadContext independent of executor life cycle, so that ThreadContext does not require a shutdown operation of its own.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>