### PR TITLE
create a spec doc starting from the current readme

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -88,7 +88,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <sourceDocumentName>microprofile-rest-client.asciidoc</sourceDocumentName>
+                    <sourceDocumentName>microprofile-concurrency.asciidoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>
                         <license>Apache License v2.0</license>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.microprofile.concurrency</groupId>
+        <artifactId>microprofile-concurrency-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>microprofile-concurrency-spec</artifactId>
+    <packaging>pom</packaging>
+
+    <name>MicroProfile Concurrency Specification</name>
+    <description>MicroProfile Concurrency :: Specification</description>
+
+    <properties>
+        <asciidoctor-maven.version>1.5.5</asciidoctor-maven.version>
+        <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
+        <license>Apache License v 2.0</license>
+        <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
+        <revisiondate>${maven.build.timestamp}</revisiondate>
+        <revremark>Draft</revremark>
+    </properties>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor-maven.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>${asciidoctorj-pdf.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>generate-pdf-doc</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${revremark}</revremark>
+                                <revdate>${revisiondate}</revdate>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-html</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${revremark}</revremark>
+                                <revdate>${revisiondate}</revdate>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDocumentName>microprofile-rest-client.asciidoc</sourceDocumentName>
+                    <sourceHighlighter>coderay</sourceHighlighter>
+                    <attributes>
+                        <license>Apache License v2.0</license>
+                    </attributes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/spec/src/main/asciidoc/builders.asciidoc
+++ b/spec/src/main/asciidoc/builders.asciidoc
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[builders]]
+== Builders for ManagedExecutor and ThreadContext
+
+MicroProfile Concurrency provides a fluent builder API to programmatically obtain instances of ManagedExecutor and ThreadContext. Builder instances are obtained via static builder() methods on ManagedExecutor and ThreadContext.
+
+=== Example ManagedExecutor Builder Usage
+
+[source, java]
+----
+    public void init(ServletConfig config) {
+        executor = ManagedExecutor.builder()
+                                  .propagated(ThreadContext.APPLICATION)
+                                  .cleared(ThreadContext.ALL_REMAINING)
+                                  .maxAsync(5)
+                                  .build();
+    }
+
+    public void doGet(HttpServletRequest req, HttpServletResponse res) {
+       completionStage = executor.runAsync(task1)
+                             .thenRunAsync(task2)
+                             ...
+    }
+
+    public void destroy() {
+        executor.shutdown();
+    }
+----
+
+Applications are encouraged to cache and reuse ManagedExecutor instances.
+It is the responsibility of the application to shut down ManagedExecutor
+instances that are no longer needed, so as to allow the container to
+efficiently free up resources.
+
+=== Example ThreadContext Builder Usage
+
+[source, java]
+----
+    threadContext = ThreadContext.builder()
+                        .propagated(ThreadContext.APPLICATION, ThreadContext.SECURITY)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+    ...
+
+    Function<Long, Long> contextFn = threadContext.contextualFunction(x -> {
+        ... operations that requires security & application context
+        return result;
+    });
+
+    // By using java.util.concurrent.CompletableFuture.supplyAsync rather
+    // than a managed executor, context propagation is unpredictable,
+    // except for the contextFn action that we pre-contextualized using
+    // MicroProfile Concurrency's ThreadContext above.
+    stage = CompletableFuture.supplyAsync(supplier)
+                             .thenApplyAsync(function1)
+                             .thenApply(contextFn)
+                             ...
+----
+
+Builder instances retain their configuration after the build method is
+invoked and can be reused. Subsequent changes to builder configuration
+apply to subsequent invocations of the build method but do not impact
+ManagedExecutors that have already been built.

--- a/spec/src/main/asciidoc/builders.asciidoc
+++ b/spec/src/main/asciidoc/builders.asciidoc
@@ -17,12 +17,24 @@
 [[builders]]
 == Builders for ManagedExecutor and ThreadContext
 
-MicroProfile Concurrency provides a fluent builder API to programmatically obtain instances of ManagedExecutor and ThreadContext. Builder instances are obtained via static builder() methods on ManagedExecutor and ThreadContext.
+MicroProfile Concurrency provides a fluent builder API to programmatically obtain instances of `ManagedExecutor` and `ThreadContext`. Builder instances are obtained via static `builder()` methods on `ManagedExecutor` and `ThreadContext`.
 
 === Example ManagedExecutor Builder Usage
 
 [source, java]
 ----
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
+import javax.servlet.ServletConfig;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+public class ExampleServlet extends HttpServlet {
+    ManagedExecutor executor;
+
     public void init(ServletConfig config) {
         executor = ManagedExecutor.builder()
                                   .propagated(ThreadContext.APPLICATION)
@@ -40,10 +52,11 @@ MicroProfile Concurrency provides a fluent builder API to programmatically obtai
     public void destroy() {
         executor.shutdown();
     }
+}
 ----
 
-Applications are encouraged to cache and reuse ManagedExecutor instances.
-It is the responsibility of the application to shut down ManagedExecutor
+Applications are encouraged to cache and reuse `ManagedExecutor` instances.
+It is the responsibility of the application to shut down `ManagedExecutor`
 instances that are no longer needed, so as to allow the container to
 efficiently free up resources.
 
@@ -51,29 +64,45 @@ efficiently free up resources.
 
 [source, java]
 ----
-    threadContext = ThreadContext.builder()
-                        .propagated(ThreadContext.APPLICATION, ThreadContext.SECURITY)
-                        .cleared(ThreadContext.ALL_REMAINING)
-                        .build();
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.servlet.ServletConfig;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.microprofile.concurrent.ThreadContext;
 
-    ...
+public class ExampleServlet extends HttpServlet {
+    ThreadContext threadContext;
 
-    Function<Long, Long> contextFn = threadContext.contextualFunction(x -> {
-        ... operations that requires security & application context
-        return result;
-    });
+    public void init(ServletConfig config) {
+        threadContext = ThreadContext.builder()
+                            .propagated(ThreadContext.APPLICATION, ThreadContext.SECURITY)
+                            .cleared(ThreadContext.ALL_REMAINING)
+                            .build();
+    }
 
-    // By using java.util.concurrent.CompletableFuture.supplyAsync rather
-    // than a managed executor, context propagation is unpredictable,
-    // except for the contextFn action that we pre-contextualized using
-    // MicroProfile Concurrency's ThreadContext above.
-    stage = CompletableFuture.supplyAsync(supplier)
-                             .thenApplyAsync(function1)
-                             .thenApply(contextFn)
-                             ...
+    public void doGet(HttpServletRequest req, HttpServletResponse res) {
+        Function<Long, Long> contextFn = threadContext.contextualFunction(x -> {
+            ... operation that requires security & application context
+            return result;
+        });
+
+        // By using java.util.concurrent.CompletableFuture.supplyAsync rather
+        // than a managed executor, context propagation is unpredictable,
+        // except for the contextFn action that we pre-contextualized using
+        // MicroProfile Concurrency's ThreadContext above.
+        stage = CompletableFuture.supplyAsync(supplier)
+                                 .thenApplyAsync(function1)
+                                 .thenApply(contextFn)
+                                 ...
+    }
+}
 ----
 
-Builder instances retain their configuration after the build method is
-invoked and can be reused. Subsequent changes to builder configuration
-apply to subsequent invocations of the build method but do not impact
-ManagedExecutors that have already been built.
+=== Reuse of Builders
+
+Instances of `ManagedExecutor.Builder` and `ThreadContext.Builder` retain their configuration after the build method is
+invoked and can be reused. Subsequent invocations of the build() method create new instances of
+`ManagedExecutor` and `ThreadContext` that operate independently of previously built instances.

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[concurrencycdi]]
+== CDI Injection
+
+If a CDI implementation is available, instances of ManagedExecutor and ThreadContext can be injected as CDI beans.
+
+TODO write the documentation after discussion on Config annotations is resolved

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -17,6 +17,6 @@
 [[concurrencycdi]]
 == CDI Injection
 
-If a CDI implementation is available, instances of ManagedExecutor and ThreadContext can be injected as CDI beans.
+If a CDI implementation is available, instances of `ManagedExecutor` and `ThreadContext` can be injected as CDI beans.
 
 TODO write the documentation after discussion on Config annotations is resolved

--- a/spec/src/main/asciidoc/concurrencyprovider.asciidoc
+++ b/spec/src/main/asciidoc/concurrencyprovider.asciidoc
@@ -17,39 +17,39 @@
 [[concurrencyprovider]]
 == Concurrency Provider
 
-A MicroProfile Concurrency implementation provides an implementation of the org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider interface via either of the following mechanisms:
+A MicroProfile Concurrency implementation provides an implementation of the `org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider` interface via either of the following mechanisms:
 
-- By manually registering the implementation via the static register(ConcurrencyProvider) method. This register returns a ConcurrencyProviderRegistration instance which can be used to unregister.
+- By manually registering the implementation via the static `register(ConcurrencyProvider)` method. This register returns a `ConcurrencyProviderRegistration` instance which can be used to unregister.
 
-- Alternately, via the ServiceLoader, by including a file of the following name and location:
+- Alternately, via the `ServiceLoader`, by including a file of the following name and location:
   `META-INF/services/org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider`.
-  The content of the aforementioned file must a single line specifying the fully qualified name of the ConcurrencyProvider implementation that is provided within the JAR file.
+  The content of the aforementioned file must a single line specifying the fully qualified name of the `ConcurrencyProvider` implementation that is provided within the JAR file.
 
-The ConcurrencyProvider implementation has one main purpose, which is to supply and maintain instances of ConcurrencyManager per class loader. This is done via the getConcurrencyManager(ClassLoader) method.
+The `ConcurrencyProvider` implementation has one main purpose, which is to supply and maintain instances of `ConcurrencyManager` per class loader. This is done via the `getConcurrencyManager(ClassLoader)` method.
 
-In the case where the ConcurrencyProvider is fully integrated with the container, all other methods of ConcurrencyProvider are optional, with their default implementations being sufficient.
+In the case where the `ConcurrencyProvider` is fully integrated with the container, all other methods of `ConcurrencyProvider` are optional, with their default implementations being sufficient.
 
-In the case where the ConcurrencyProvider implementation is distinct from the container, several other methods are made available to allow the container to build new instances of ConcurrencyManager (via getConcurrencyManagerBuilder), register these instances with the ConcurrencyProvider per class loader (registerConcurrencyManager), and unregister these instances when the class loader is no longer valid (releaseConcurrencyManager).
+In the case where the `ConcurrencyProvider` implementation is distinct from the container, several other methods are made available to allow the container to build new instances of `ConcurrencyManager` (via `getConcurrencyManagerBuilder`), register these instances with the `ConcurrencyProvider` per class loader (`registerConcurrencyManager`), and unregister these instances when the class loader is no longer valid (`releaseConcurrencyManager`).
 
 === Concurrency Manager
 
-ConcurrencyManager's purpose is to provide builders for ManagedExecutor and ThreadContext. The builders create instances of ManagedExecutor and ThreadContext where thread context management is based on the ThreadContextProviders that are accessible to the ServiceLoader from the class loader that is associated with the ConcurrencyManager instance.
+`ConcurrencyManager`'s purpose is to provide builders for `ManagedExecutor` and `ThreadContext`. The builders create instances of `ManagedExecutor` and `ThreadContext` where thread context management is based on the `ThreadContextProvider`s that are accessible to the `ServiceLoader` from the class loader that is associated with the `ConcurrencyManager` instance.
 
 === Concurrency Manager Builder
 
-The builder for ConcurrencyManager is optional if the ConcurrencyProvider is inseparable from the container, in which case there is no need to provide an implementation.
+The builder for `ConcurrencyManager` is optional if the `ConcurrencyProvider` is inseparable from the container, in which case there is no need to provide an implementation.
 
-This builder enables the container to create customized instances of ConcurrencyManager for a particular class loader. The container can choose to have thread context providers loaded from the class loader (addDiscoveredThreadContextProviders) or manually supply its own (withThreadContextProviders). Similarly, the container can choose to have extensions loaded from the class loader (addDiscoveredConcurrencyManagerExtensions) or provide its own (withConcurrencyManagerExtensions). The container is responsible for managing registration and unregistration of all ConcurrencyManager instances that it builds.
+This builder enables the container to create customized instances of `ConcurrencyManager` for a particular class loader. The container can choose to have thread context providers loaded from the class loader (`addDiscoveredThreadContextProviders`) or manually supply its own (`withThreadContextProviders`). Similarly, the container can choose to have extensions loaded from the class loader (`addDiscoveredConcurrencyManagerExtensions`) or provide its own (`withConcurrencyManagerExtensions`). The container is responsible for managing registration and unregistration of all `ConcurrencyManager` instances that it builds.
 
 === Concurrency Manager Extension
 
-ConcurrencyManagerExtension is an optional plugin point that allows you to receive notification upon creation of each ConcurrencyManager. This serves as a convenient invocation point for enabling system wide context propagator hooks. After creating each ConcurrencyManager, the MicroProfile Concurrency implementation queries the ServiceLoader for implementations of org.eclipse.microprofile.concurrent.spi.ConcurrencyManagerExtension and invokes the setup method of each.
+`ConcurrencyManagerExtension` is an optional plugin point that allows you to receive notification upon creation of each `ConcurrencyManager`. This serves as a convenient invocation point for enabling system wide context propagator hooks. After creating each `ConcurrencyManager`, the MicroProfile Concurrency implementation queries the `ServiceLoader` for implementations of `org.eclipse.microprofile.concurrent.spi.ConcurrencyManagerExtension` and invokes the setup method of each.
 
-To register a ConcurrencyManagerExtension, a JAR file that is accessible from the class loader associated with the ConcurrencyManager must include a file of the following name and location,
+To register a `ConcurrencyManagerExtension`, a JAR file that is accessible from the class loader associated with the `ConcurrencyManager` must include a file of the following name and location,
 
 [source]
 ----
 META-INF/services/org.eclipse.microprofile.concurrent.spi.ConcurrencyManagerExtension
 ----
 
-The content of the aforementioned file must be one or more lines, each specifying the fully qualified name of a ConcurrencyManagerExtension implementation that is provided within the JAR file.
+The content of the aforementioned file must be one or more lines, each specifying the fully qualified name of a `ConcurrencyManagerExtension` implementation that is provided within the JAR file.

--- a/spec/src/main/asciidoc/concurrencyprovider.asciidoc
+++ b/spec/src/main/asciidoc/concurrencyprovider.asciidoc
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[concurrencyprovider]]
+== Concurrency Provider
+
+A MicroProfile Concurrency implementation provides an implementation of the org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider interface via either of the following mechanisms:
+
+- By manually registering the implementation via the static register(ConcurrencyProvider) method. This register returns a ConcurrencyProviderRegistration instance which can be used to unregister.
+
+- Alternately, via the ServiceLoader, by including a file of the following name and location:
+  `META-INF/services/org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider`.
+  The content of the aforementioned file must a single line specifying the fully qualified name of the ConcurrencyProvider implementation that is provided within the JAR file.
+
+The ConcurrencyProvider implementation has one main purpose, which is to supply and maintain instances of ConcurrencyManager per class loader. This is done via the getConcurrencyManager(ClassLoader) method.
+
+In the case where the ConcurrencyProvider is fully integrated with the container, all other methods of ConcurrencyProvider are optional, with their default implementations being sufficient.
+
+In the case where the ConcurrencyProvider implementation is distinct from the container, several other methods are made available to allow the container to build new instances of ConcurrencyManager (via getConcurrencyManagerBuilder), register these instances with the ConcurrencyProvider per class loader (registerConcurrencyManager), and unregister these instances when the class loader is no longer valid (releaseConcurrencyManager).
+
+=== Concurrency Manager
+
+ConcurrencyManager's purpose is to provide builders for ManagedExecutor and ThreadContext. The builders create instances of ManagedExecutor and ThreadContext where thread context management is based on the ThreadContextProviders that are accessible to the ServiceLoader from the class loader that is associated with the ConcurrencyManager instance.
+
+=== Concurrency Manager Builder
+
+The builder for ConcurrencyManager is optional if the ConcurrencyProvider is inseparable from the container, in which case there is no need to provide an implementation.
+
+This builder enables the container to create customized instances of ConcurrencyManager for a particular class loader. The container can choose to have thread context providers loaded from the class loader (addDiscoveredThreadContextProviders) or manually supply its own (withThreadContextProviders). Similarly, the container can choose to have extensions loaded from the class loader (addDiscoveredConcurrencyManagerExtensions) or provide its own (withConcurrencyManagerExtensions). The container is responsible for managing registration and unregistration of all ConcurrencyManager instances that it builds.
+
+=== Concurrency Manager Extension
+
+ConcurrencyManagerExtension is an optional plugin point that allows you to receive notification upon creation of each ConcurrencyManager. This serves as a convenient invocation point for enabling system wide context propagator hooks. After creating each ConcurrencyManager, the MicroProfile Concurrency implementation queries the ServiceLoader for implementations of org.eclipse.microprofile.concurrent.spi.ConcurrencyManagerExtension and invokes the setup method of each.
+
+To register a ConcurrencyManagerExtension, a JAR file that is accessible from the class loader associated with the ConcurrencyManager must include a file of the following name and location,
+
+[source]
+----
+META-INF/services/org.eclipse.microprofile.concurrent.spi.ConcurrencyManagerExtension
+----
+
+The content of the aforementioned file must be one or more lines, each specifying the fully qualified name of a ConcurrencyManagerExtension implementation that is provided within the JAR file.

--- a/spec/src/main/asciidoc/contextproviders.asciidoc
+++ b/spec/src/main/asciidoc/contextproviders.asciidoc
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[thread_context_providers]]
+== Thread Context Providers
+
+The initial release of EE Concurrency assumed a single monolithic implementation of the full set of EE specifications that could thus rely on vendor-specific internals to achieve context propagation. However, in practice, open source implementations of various specs are often pieced together into a comprehensive solution.
+
+The thread context provider SPI is defined to bridge the gap, allowing any provider of thread context to publish and make available the type of thread context it supports, following a standard and predictable pattern that can be relied upon by a MicroProfile Concurrency implementation, enabling it to facilitate the inclusion of any generic thread context alongside the spec-defined thread context types that it captures and propagates.
+
+With this model, the provider of thread context implements the org.eclipse.microprofile.concurrent.spi.ThreadContextProvider interface and packages it in a way that makes it available to the ServiceLoader. ThreadContextProvider identifies the thread context type and provides a way to capture snapshots of thread context as well as for applying empty/cleared context to threads.
+
+
+=== Example
+
+The following is a working example of a thread context provider and related interfaces.
+The example context type that it propagates is the priority of a thread. This is chosen, not because it is useful in any way, but because the concept of thread priority is simple, well understood, and already built into Java, allowing the reader to focus on the mechanisms of thread context capture/propagate/restore rather than the details of the context type itself.
+
+==== ThreadContextProvider
+
+The interface, org.eclipse.microprofile.concurrent.spi.ThreadContextProvider, is the first point of interaction between the MicroProfile Concurrency implementation and a thread context provider. This interface is the means by which the MicroProfile Concurrency implementation requests the capturing of a particular context type from the current thread. It also provides a way to obtain a snapshot of empty/cleared context of this type and identifies the name by which the user refers to this context type when configuring a ManagedExecutor or ThreadContext.
+
+[source, java]
+----
+package org.eclipse.microprofile.example.context.priority;
+
+import java.util.Map;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+public class ThreadPriorityContextProvider implements ThreadContextProvider {
+    public String getThreadContextType() {
+        return "ThreadPriority";
+    }
+
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new ThreadPrioritySnapshot(Thread.currentThread().getPriority());
+    }
+
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new ThreadPrioritySnapshot(Thread.NORM_PRIORITY);
+    }
+}
+----
+
+==== ThreadContextSnapshot
+
+The interface, org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot, represents an immutable snapshot of thread context. The MicroProfile Concurrency implementation can request the context represented by this snapshot to be applied to any number of threads by invoking the the begin method. The begin method must save the previous context of the thread so that it can return an instance of org.eclipse.microprofile.concurrent.spi.ThreadContextController for one-time use by the MicroProfile Concurrency implementation to restore the previous context after the context represented by the snapshot is no longer needed on the thread.
+
+[source, java]
+----
+package org.eclipse.microprofile.example.context.priority;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+public class ThreadPrioritySnapshot implements ThreadContextSnapshot {
+    private final int priority;
+
+    ThreadPrioritySnapshot(int priority) {
+        this.priority = priority;
+    }
+
+    public ThreadContextController begin() {
+        Thread thread = Thread.currentThread();
+        int priorityToRestore = thread.getPriority();
+        AtomicBoolean restored = new AtomicBoolean();
+
+        ThreadContextController contextRestorer = () -> {
+            if (restored.compareAndSet(false, true))
+                thread.setPriority(priorityToRestore);
+            else
+                throw new IllegalStateException();
+        };
+
+        thread.setPriority(priority);
+
+        return contextRestorer;
+    }
+}
+----
+
+==== ServiceLoader entry
+
+To make the ThreadContextProvider implementation available to the ServiceLoader, the provider JAR includes a file of the following name and location,
+
+[source]
+----
+META-INF/services/org.eclipse.microprofile.concurrent.spi.ThreadContextProvider
+----
+
+The content of the aforementioned file must be one or more lines, each specifying the fully qualified name of a ThreadContextProvider implementation that is provided within the JAR file. For our example context provider, this file consists of the following line:
+
+[source]
+----
+org.eclipse.microprofile.example.context.priority.ThreadPriorityContextProvider
+----
+
+==== Usage from Application
+
+The following example shows application code that uses a ManagedExecutor that propagates the example context type. If the provider is implemented correctly and made available on the application's thread context class loader, the async Runnable should report that it is running with a priority of 3.
+
+[source, java]
+----
+    ManagedExecutor executor = ManagedExecutor.builder()
+                                              .propagated("ThreadPriority")
+                                              .cleared(ThreadContext.ALL_REMAINING)
+                                              .build();
+    Thread.currentThread().setPriority(3);
+
+    executor.runAsync(() -> {
+        System.out.println("Running with priority of " +
+            Thread.currentThread().getPriority());
+    });
+----

--- a/spec/src/main/asciidoc/contextproviders.asciidoc
+++ b/spec/src/main/asciidoc/contextproviders.asciidoc
@@ -21,7 +21,7 @@ The initial release of EE Concurrency assumed a single monolithic implementation
 
 The thread context provider SPI is defined to bridge the gap, allowing any provider of thread context to publish and make available the type of thread context it supports, following a standard and predictable pattern that can be relied upon by a MicroProfile Concurrency implementation, enabling it to facilitate the inclusion of any generic thread context alongside the spec-defined thread context types that it captures and propagates.
 
-With this model, the provider of thread context implements the org.eclipse.microprofile.concurrent.spi.ThreadContextProvider interface and packages it in a way that makes it available to the ServiceLoader. ThreadContextProvider identifies the thread context type and provides a way to capture snapshots of thread context as well as for applying empty/cleared context to threads.
+With this model, the provider of thread context implements the `org.eclipse.microprofile.concurrent.spi.ThreadContextProvider` interface and packages it in a way that makes it available to the `ServiceLoader`. `ThreadContextProvider` identifies the thread context type and provides a way to capture snapshots of thread context as well as for applying empty/cleared context to threads.
 
 
 === Example
@@ -31,7 +31,7 @@ The example context type that it propagates is the priority of a thread. This is
 
 ==== ThreadContextProvider
 
-The interface, org.eclipse.microprofile.concurrent.spi.ThreadContextProvider, is the first point of interaction between the MicroProfile Concurrency implementation and a thread context provider. This interface is the means by which the MicroProfile Concurrency implementation requests the capturing of a particular context type from the current thread. It also provides a way to obtain a snapshot of empty/cleared context of this type and identifies the name by which the user refers to this context type when configuring a ManagedExecutor or ThreadContext.
+The interface, `org.eclipse.microprofile.concurrent.spi.ThreadContextProvider`, is the first point of interaction between the MicroProfile Concurrency implementation and a thread context provider. This interface is the means by which the MicroProfile Concurrency implementation requests the capturing of a particular context type from the current thread. It also provides a way to obtain a snapshot of empty/cleared context of this type and identifies the name by which the user refers to this context type when configuring a `ManagedExecutor` or `ThreadContext`.
 
 [source, java]
 ----
@@ -58,7 +58,7 @@ public class ThreadPriorityContextProvider implements ThreadContextProvider {
 
 ==== ThreadContextSnapshot
 
-The interface, org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot, represents an immutable snapshot of thread context. The MicroProfile Concurrency implementation can request the context represented by this snapshot to be applied to any number of threads by invoking the the begin method. The begin method must save the previous context of the thread so that it can return an instance of org.eclipse.microprofile.concurrent.spi.ThreadContextController for one-time use by the MicroProfile Concurrency implementation to restore the previous context after the context represented by the snapshot is no longer needed on the thread.
+The interface, `org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot`, represents a snapshot of thread context. The MicroProfile Concurrency implementation can request the context represented by this snapshot to be applied to any number of threads by invoking the `begin` method. An instance of  `org.eclipse.microprofile.concurrent.spi.ThreadContextController`, which is returned by the `begin` method, stores the previous context of the thread. The `ThreadContextController` instance provided for one-time use by the MicroProfile Concurrency implementation to restore the previous context after the context represented by the snapshot is no longer needed on the thread.
 
 [source, java]
 ----
@@ -96,14 +96,14 @@ public class ThreadPrioritySnapshot implements ThreadContextSnapshot {
 
 ==== ServiceLoader entry
 
-To make the ThreadContextProvider implementation available to the ServiceLoader, the provider JAR includes a file of the following name and location,
+To make the `ThreadContextProvider` implementation available to the `ServiceLoader`, the provider JAR includes a file of the following name and location,
 
 [source]
 ----
 META-INF/services/org.eclipse.microprofile.concurrent.spi.ThreadContextProvider
 ----
 
-The content of the aforementioned file must be one or more lines, each specifying the fully qualified name of a ThreadContextProvider implementation that is provided within the JAR file. For our example context provider, this file consists of the following line:
+The content of the aforementioned file must be one or more lines, each specifying the fully qualified name of a `ThreadContextProvider` implementation that is provided within the JAR file. For our example context provider, this file consists of the following line:
 
 [source]
 ----
@@ -112,7 +112,7 @@ org.eclipse.microprofile.example.context.priority.ThreadPriorityContextProvider
 
 ==== Usage from Application
 
-The following example shows application code that uses a ManagedExecutor that propagates the example context type. If the provider is implemented correctly and made available on the application's thread context class loader, the async Runnable should report that it is running with a priority of 3.
+The following example shows application code that uses a `ManagedExecutor` that propagates the example context type. If the provider is implemented correctly and made available on the application's thread context class loader, the async `Runnable` should report that it is running with a priority of 3.
 
 [source, java]
 ----

--- a/spec/src/main/asciidoc/examples.asciidoc
+++ b/spec/src/main/asciidoc/examples.asciidoc
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[examples]]
+== MicroProfile Concurrency Examples
+
+This page includes some additional examples of spec usage.
+
+=== Contextualize a new CompletableFuture and all dependent stages
+
+[source, java]
+----
+    executor = ManagedExecutor.builder()
+                   .cleared(ThreadContext.TRANSACTION, ThreadContext.SECURITY)
+                   .propagated(ThreadContext.ALL_REMAINING)
+                   .build();
+
+    CompletableFuture<Long> stage1 = executor.newIncompleteFuture();
+    stage1.thenApply(function1)      // runs with captured context
+          .thenApply(function2);     // runs with captured context
+    stage1.completeAsync(supplier1); // runs with captured context
+----
+
+=== Apply thread context to a single CompletionStage action
+
+[source, java]
+----
+    threadContext = ThreadContext.builder()
+                        .propagated(ThreadContext.SECURITY)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+    Consumer<String> contextualConsumer = threadContext.contextualConsumer(s -> {
+        ... do something that requires context
+    });
+
+    stage = invokeSomeMethodThatReturnsUnmanagedCompletionStage();
+    stage.thenApply(function1)            // context is unpredictable
+         .thenAccept(contextualConsumer); // runs with captured context
+----
+
+=== Reusable Context Snapshot
+
+[source, java]
+----
+    threadContext = ThreadContext.builder().build();
+    contextSnapshot = threadContext.currentContextExecutor();
+
+    ... on some other thread,
+    contextSnapshot.execute(() -> {
+        ... do something that requires the previously captured context
+    });
+----
+
+=== Run under the transaction of the executing thread
+
+[source, java]
+----
+    threadContext = ThreadContext.builder()
+                        .propagated(ThreadContext.APPLICATION)
+                        .unchanged(ThreadContext.TRANSACTION)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+    Callable<Integer> updateDatabase = () -> {
+        DataSource ds = InitialContext.doLookup("java:comp/env/ds1");
+        try (Connection con = ds.getConnection()) {
+            return con.createStatement().executeUpdate(sql);
+        }
+    });
+
+    ... on some other thread,
+
+    tx.begin();
+    ... do transactional work
+    updateDatabase.call(); // runs as part of the transaction
+    ... more transactional work
+    tx.commit();
+----

--- a/spec/src/main/asciidoc/examples.asciidoc
+++ b/spec/src/main/asciidoc/examples.asciidoc
@@ -17,7 +17,7 @@
 [[examples]]
 == MicroProfile Concurrency Examples
 
-This page includes some additional examples of spec usage.
+This section includes some additional examples of spec usage.
 
 === Contextualize a new CompletableFuture and all dependent stages
 

--- a/spec/src/main/asciidoc/license-alv2.asciidoc
+++ b/spec/src/main/asciidoc/license-alv2.asciidoc
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[subs="normal"]
+....
+
+Specification: {doctitle}
+
+Version: {revnumber}
+
+Status: {revremark}
+
+Release: {revdate}
+
+Copyright (c) 2018 Contributors to the Eclipse Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+....

--- a/spec/src/main/asciidoc/microprofile-concurrency.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-concurrency.asciidoc
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+= MicroProfile Concurrency
+:authors: 
+:email: 
+:version-label!:
+:sectanchors:
+:doctype: book
+:license: Apache License v2.0
+:source-highlighter: coderay
+:toc: left
+:toclevels: 4
+:sectnumlevels: 4
+ifdef::backend-pdf[]
+:pagenums:
+endif::[]
+
+
+include::license-alv2.asciidoc[]
+
+== Microprofile Concurrency
+
+include::overview.asciidoc[]
+
+include::builders.asciidoc[]
+
+include::cdi.asciidoc[]
+
+include::examples.asciidoc[]
+
+include::contextproviders.asciidoc[]
+
+include::concurrencyprovider.asciidoc[]
+
+include::release_notes.asciidoc[]
+

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[concurrencyspec]]
+== MicroProfile Concurrency Specification
+
+=== Introduction
+
+MicroProfile Concurrency introduces APIs for obtaining CompletableFutures that are backed by managed threads (threads that are managed by the container), with the ability to capture context from the thread that creates the CompletableFuture and apply it when running the CompletionStage action.
+
+=== Motivation
+
+When using a reactive model with dependent stages which execute upon completion of prior stages, the context under which dependent stages execute is unpredictable. Dependent stages might run with the context of a thread that awaits completion, or the context of a previous stage that completed and triggered the dependent stage, or with no/undefined context at all. Existing solutions for transferring thread context, such as the EE Concurrency Utilities ContextService, are difficult to use and require a lot of boilerplate code. This specification makes it possible for thread context propagation to easily be done in a type-safe way, keeping boilerplate code to a minimum, as well as allowing for thread context propagation to be done automatically when using a CompletableFuture.
+
+It is also important that CompletableFutures and their dependent stages, and dependent stages created by those stages, and so on, all run on threads that are known by the container and properly managed by it. This specification makes it possible to do so by providing an API by which the user obtains managed CompletableFuture instances from a managed executor.
+
+Goals
+
+    - Proper management of CompletableFuture threads by the container.
+
+    - Mechanism for thread context propagation to CompletableFuture actions that reduces the need for boilerplate code.
+
+    - Full compatibility with EE Concurrency spec, such that proposed interfaces can eventually be seamlessly merged into EE Concurrency.
+
+=== Solution
+
+This specification introduces two interfaces that contain methods that we hope will eventually be added to Jakarta EE Concurrency.
+
+The interface, org.eclipse.microprofile.concurrent.ManagedExecutor, provides methods for obtaining managed instances of CompletableFuture which are backed by the managed executor as the default asynchronous execution facility and the default mechanism of defining thread context propagation. Similar to EE Concurrency’s ManagedExecutorService, the MicroProfile ManagedExecutor also implements the Java SE java.util.concurrent.ExecutorService interface, using managed threads when asynchronous invocation is required and disallowing the same life cycle methods as ManagedExecutorService. It is intended that ManagedExecutor methods will one day be added to ManagedExecutorService, and for a single implementation to be capable of simultaneously implementing both interfaces, both currently as well as after adoption into Jakarta EE.
+
+A second interface, org.eclipse.microprofile.concurrent.ThreadContext, provides methods for individually contextualizing dependent stage actions. This gives the user finer-grained control over the capture and propagation of thread context. It is intended that ThreadContext methods will one day be added to EE Concurrency’s ContextService and for a single implementation to be capable of simultaneously implementing both interfaces, both currently as well as after adoption into Jakarta EE.
+
+=== Builders
+
+Instances of ManagedExecutor and ThreadContext can be constructed via builders with fluent API, for example,
+
+[source, java]
+----
+    ManagedExecutor executor = ManagedExecutor.builder()
+        .propagated(ThreadContext.APPLICATION)
+        .maxAsync(5)
+        .build();
+
+    ThreadContext threadContext = ThreadContext.builder()
+        .propagated(ThreadContext.APPLICATION, ThreadContext.CDI)
+        .cleared(ThreadContext.ALL_REMAINING)
+        .build();
+----
+
+Applications should shut down ManagedExecutors that they build after they are no longer needed. The shutdown request serves as a signal notifying the container that resources can be safely cleaned up.
+
+=== Injection
+
+Instances of ManagedExecutor and ThreadContext can be injected into CDI beans via the `@Inject` annotation, for example:
+
+[source, java]
+----
+    @Inject ManagedExecutor executor;
+    @Inject ThreadContext threadContext;
+    ...
+    CompletableFuture<Integer> stage = executor
+        .supplyAsync(supplier1)
+        .thenApplyAsync(function1)
+        .thenApply(function2);
+    ...
+    unmanagedCompletionStage.thenApply(threadContext.contextualFunction(function3));
+----
+
+The container provides instances of ManagedExecutor and ThreadContext, which are injected above.
+
+=== Injection of Configured Instances
+
+TODO write this section after discussion about the Config annotations is resolved.
+
+=== Thread Context Provider SPI
+
+External providers of thread context can implement an SPI standardized by the MicroProfile Concurrency specification that allows capture/clear/propagate/restore operations to be plugged in for third party implementations of context.

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -19,19 +19,19 @@
 
 === Introduction
 
-MicroProfile Concurrency introduces APIs for obtaining CompletableFutures that are backed by managed threads (threads that are managed by the container), with the ability to capture context from the thread that creates the CompletableFuture and apply it when running the CompletionStage action.
+MicroProfile Concurrency introduces APIs for obtaining instances of `CompletableFuture` that are backed by managed threads (threads that are managed by the container), with the ability to capture context from the thread that creates the `CompletableFuture` and apply it when running the associated action.
 
 === Motivation
 
-When using a reactive model with dependent stages which execute upon completion of prior stages, the context under which dependent stages execute is unpredictable. Dependent stages might run with the context of a thread that awaits completion, or the context of a previous stage that completed and triggered the dependent stage, or with no/undefined context at all. Existing solutions for transferring thread context, such as the EE Concurrency Utilities ContextService, are difficult to use and require a lot of boilerplate code. This specification makes it possible for thread context propagation to easily be done in a type-safe way, keeping boilerplate code to a minimum, as well as allowing for thread context propagation to be done automatically when using a CompletableFuture.
+When using a reactive model with dependent stages which execute upon completion of prior stages, the context under which dependent stages execute is unpredictable. Dependent stages might run with the context of a thread that awaits completion, or the context of a previous stage that completed and triggered the dependent stage, or with no/undefined context at all. Existing solutions for transferring thread context, such as the EE Concurrency Utilities `ContextService`, are difficult to use and require a lot of boilerplate code. This specification makes it possible for thread context propagation to easily be done in a type-safe way, keeping boilerplate code to a minimum, as well as allowing for thread context propagation to be done automatically when using a `CompletableFuture`.
 
-It is also important that CompletableFutures and their dependent stages, and dependent stages created by those stages, and so on, all run on threads that are known by the container and properly managed by it. This specification makes it possible to do so by providing an API by which the user obtains managed CompletableFuture instances from a managed executor.
+It is also important that a `CompletableFuture` and its dependent stages, and dependent stages created by those stages, and so on, all run on threads that are known by the container and properly managed by it. This specification makes it possible to do so by providing an API by which the user obtains managed `CompletableFuture` instances from a managed executor.
 
 Goals
 
-    - Proper management of CompletableFuture threads by the container.
+    - Proper management of `CompletableFuture` threads by the container.
 
-    - Mechanism for thread context propagation to CompletableFuture actions that reduces the need for boilerplate code.
+    - Mechanism for thread context propagation to `CompletableFuture` actions that reduces the need for boilerplate code.
 
     - Full compatibility with EE Concurrency spec, such that proposed interfaces can eventually be seamlessly merged into EE Concurrency.
 
@@ -39,13 +39,13 @@ Goals
 
 This specification introduces two interfaces that contain methods that we hope will eventually be added to Jakarta EE Concurrency.
 
-The interface, org.eclipse.microprofile.concurrent.ManagedExecutor, provides methods for obtaining managed instances of CompletableFuture which are backed by the managed executor as the default asynchronous execution facility and the default mechanism of defining thread context propagation. Similar to EE Concurrency’s ManagedExecutorService, the MicroProfile ManagedExecutor also implements the Java SE java.util.concurrent.ExecutorService interface, using managed threads when asynchronous invocation is required and disallowing the same life cycle methods as ManagedExecutorService. It is intended that ManagedExecutor methods will one day be added to ManagedExecutorService, and for a single implementation to be capable of simultaneously implementing both interfaces, both currently as well as after adoption into Jakarta EE.
+The interface, `org.eclipse.microprofile.concurrent.ManagedExecutor`, provides methods for obtaining managed instances of `CompletableFuture` which are backed by the managed executor as the default asynchronous execution facility and the default mechanism of defining thread context propagation. Similar to EE Concurrency’s `ManagedExecutorService`, the MicroProfile `ManagedExecutor` also implements the Java SE `java.util.concurrent.ExecutorService` interface, using managed threads when asynchronous invocation is required. It is intended that `ManagedExecutor` methods will one day be added to `ManagedExecutorService`, and for a single implementation to be capable of simultaneously implementing both interfaces, both currently as well as after adoption into Jakarta EE.
 
-A second interface, org.eclipse.microprofile.concurrent.ThreadContext, provides methods for individually contextualizing dependent stage actions. This gives the user finer-grained control over the capture and propagation of thread context. It is intended that ThreadContext methods will one day be added to EE Concurrency’s ContextService and for a single implementation to be capable of simultaneously implementing both interfaces, both currently as well as after adoption into Jakarta EE.
+A second interface, `org.eclipse.microprofile.concurrent.ThreadContext`, provides methods for individually contextualizing dependent stage actions. This gives the user finer-grained control over the capture and propagation of thread context. It is intended that ThreadContext methods will one day be added to EE Concurrency’s `ContextService` and for a single implementation to be capable of simultaneously implementing both interfaces, both currently as well as after adoption into Jakarta EE.
 
 === Builders
 
-Instances of ManagedExecutor and ThreadContext can be constructed via builders with fluent API, for example,
+Instances of `ManagedExecutor` and `ThreadContext` can be constructed via builders with fluent API, for example,
 
 [source, java]
 ----
@@ -60,11 +60,11 @@ Instances of ManagedExecutor and ThreadContext can be constructed via builders w
         .build();
 ----
 
-Applications should shut down ManagedExecutors that they build after they are no longer needed. The shutdown request serves as a signal notifying the container that resources can be safely cleaned up.
+Applications should shut down instances of `ManagedExecutor` that they build after they are no longer needed. The shutdown request serves as a signal notifying the container that resources can be safely cleaned up.
 
 === Injection
 
-Instances of ManagedExecutor and ThreadContext can be injected into CDI beans via the `@Inject` annotation, for example:
+Instances of `ManagedExecutor` and `ThreadContext` can be injected into CDI beans via the `@Inject` annotation, for example:
 
 [source, java]
 ----
@@ -79,7 +79,7 @@ Instances of ManagedExecutor and ThreadContext can be injected into CDI beans vi
     unmanagedCompletionStage.thenApply(threadContext.contextualFunction(function3));
 ----
 
-The container provides instances of ManagedExecutor and ThreadContext, which are injected above.
+The container provides default instances of `ManagedExecutor` and `ThreadContext`, as injected above, which are shared within an application with all other injection points for `ManagedExecutor` and `ThreadContext` that do not specify a qualifier. Their configuration is equivalent to `ManagedExecutor.builder().build()` and `ThreadContext.builder().build()`.
 
 === Injection of Configured Instances
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -25,7 +25,7 @@ http://download.eclipse.org/microprofile/microprofile-concurrency-1.0/apidocs/[M
 
 Key features:
 
-- CompletableFuture/CompletionStage implementations with predictable thread context and  using managed threads for async actions
+- `CompletableFuture`/`CompletionStage` implementations with predictable thread context and  using managed threads for async actions
 - Ability to contextualize only specific actions/tasks
 - Compatibility with EE Concurrency
 - CDI injection as well as builder pattern
@@ -43,7 +43,7 @@ To get started, add this dependency to your project:
 </dependency>
 ----
 
-Use CDI to inject a ManagedExecutor or ThreadContext service:
+Use CDI to inject a `ManagedExecutor` or `ThreadContext` service:
 
 [source,java]
 ----
@@ -61,7 +61,7 @@ Or you can create one using a builder:
                        .build();
 ----
 
-Then obtain a CompletableFuture or CompletionStage from the ManagedExecutor, and from there use it the same as Java SE:
+Then obtain a `CompletableFuture` or `CompletionStage` from the `ManagedExecutor`, and from there use it the same as Java SE:
 
 [source,java]
 ----

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[release_notes_10]]
+== Release Notes for MicroProfile Concurrency 1.0
+
+http://download.eclipse.org/microprofile/microprofile-concurrency-1.0/microprofile-concurrency.pdf[MicroProfile Concurrency Spec PDF]
+http://download.eclipse.org/microprofile/microprofile-concurrency-1.0/microprofile-concurrency.html[MicroProfile Concurrency Spec HTML]
+http://download.eclipse.org/microprofile/microprofile-concurrency-1.0/apidocs/[MicroProfile Concurrency Spec Javadocs]
+
+Key features:
+
+- CompletableFuture/CompletionStage implementations with predictable thread context and  using managed threads for async actions
+- Ability to contextualize only specific actions/tasks
+- Compatibility with EE Concurrency
+- CDI injection as well as builder pattern
+- Configurable via MicroProfile Config
+
+To get started, add this dependency to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.eclipse.microprofile.concurrency</groupId>
+    <artifactId>microprofile-concurrency-api</artifactId>
+    <version>1.0</version>
+    <scope>provided</scope>
+</dependency>
+----
+
+Use CDI to inject a ManagedExecutor or ThreadContext service:
+
+[source,java]
+----
+public class MyBean {
+    @Inject ManagedExecutor executor;
+----
+
+Or you can create one using a builder:
+
+[source,java]
+----
+    ManagedExecutor executor = ManagedExecutor.builder()
+                       .propagated(ThreadContext.APPLICATION, ThreadContext.CDI)
+                       .maxAsync(5)
+                       .build();
+----
+
+Then obtain a CompletableFuture or CompletionStage from the ManagedExecutor, and from there use it the same as Java SE:
+
+[source,java]
+----
+    CompletableFuture<Integer> cf1 = executor.supplyAsync(supplier1)
+                                             .thenApplyAsync(function1)
+                                             .thenApply(function2);
+----


### PR DESCRIPTION
Convert the existing readme, which we had been using as our spec documentation into official spec doc with separate pages.

Most of the readme, especially regarding application usage has been converted into the overview.asciidoc file.  The contextproviders.asciidoc file contains the parts of the readme that concern the SPI, to which an oversimplified example context provider is added.
The following pages are entirely new:
builders.asciidoc, examples.asciidoc, concurrencyprovider.asciidoc

TODO comments are intentionally included on the cdi page and the section of the overview for CDI injection because of the ongoing discussion that needs to be resolved before these can be written.  A separate pull request will be made for this work.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>