### PR TITLE
Issue #55 introduce annotation literals for ManagedExecutorConfig, Th…

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -27,6 +27,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.util.AnnotationLiteral;
+
 /**
  * <p>Annotates a CDI injection point for a {@link ManagedExecutor} such that the container
  * creates a new instance, which is identified within an application by its unique name.
@@ -164,4 +166,47 @@ public @interface ManagedExecutorConfig {
      * <code>maxQueued</code> value is 0 or less than -1.
      */
     int maxQueued() default -1;
+
+        /**
+        * Util class used for inline creation of {@link ManagedExecutorConfig} annotation instances.
+        */
+        public final class Literal extends AnnotationLiteral<ManagedExecutorConfig> implements ManagedExecutorConfig {
+
+            public static final Literal DEFAULT_INSTANCE = 
+                of(-1, -1, new String[]{ThreadContext.TRANSACTION}, new String[]{ThreadContext.ALL_REMAINING});
+
+            private static final long serialVersionUID = 1L;
+
+            private final int maxAsync;
+            private final int maxQueued;
+            private final String[] cleared;
+            private final String[] propagated;
+
+            public int maxAsync() {
+                return maxAsync;
+            }
+
+            public int maxQueued() {
+                return maxQueued;
+            }
+
+            public String[] cleared() {
+                return cleared;
+            }
+
+            public String[] propagated() {
+                return propagated;
+            }
+
+            public static Literal of(int maxAsync, int maxQueued, String[] cleared, String[] propagated) {
+                return new Literal(maxAsync, maxQueued, cleared, propagated);
+            }
+
+            private Literal(int maxAsync, int maxQueued, String[] cleared, String[] propagated) {
+                this.cleared = cleared;
+                this.propagated = propagated;
+                this.maxAsync = maxAsync;
+                this.maxQueued = maxQueued;
+            }
+        }
 }

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/NamedInstance.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/NamedInstance.java
@@ -27,6 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
@@ -75,4 +76,26 @@ public @interface NamedInstance {
      * Unique name that qualifies a {@link ManagedExecutor} or {@link ThreadContext}.
      */
     String value();
+    
+    /**
+     * Supports inline instantiation of the {@link NamedInstance} qualifier.
+     *
+     */
+    public final class Literal extends AnnotationLiteral<NamedInstance> implements NamedInstance {
+
+        private static final long serialVersionUID = 1L;
+        private final String value;
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        public String value() {
+            return value;
+        }
+
+        private Literal(String value) {
+            this.value = value;
+        }
+    }
 }

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -27,6 +27,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.util.AnnotationLiteral;
+
 /**
  * <p>Annotates a CDI injection point for a {@link ThreadContext} such that the container
  * creates a new instance, which is identified within an application by its unique name.
@@ -165,4 +167,40 @@ public @interface ThreadContextConfig {
      * includes one or more of the same types as this set.</p>
      */
     String[] unchanged() default {};
+    
+        /**
+        * Util class used for inline creation of {@link ThreadContextConfig} annotation instances.
+        */
+        public final class Literal extends AnnotationLiteral<ThreadContextConfig> implements ThreadContextConfig {
+
+            public static final Literal DEFAULT_INSTANCE = 
+                of(new String[]{ThreadContext.TRANSACTION}, new String[]{}, new String[]{ThreadContext.ALL_REMAINING});;
+
+            private static final long serialVersionUID = 1L;
+
+            private final String[] cleared;
+            private final String[] unchanged;
+            private final String[] value;
+
+            public String[] cleared() {
+                return cleared;
+            }
+
+            public String[] unchanged() {
+                return unchanged;
+            }
+            public String[] value() {
+                return value;
+            }
+
+            public static Literal of(String[] cleared, String[] unchanged, String[] value) {
+                return new Literal(cleared, unchanged, value);
+            }
+
+            private Literal(String[] cleared, String[] unchanged, String[] value) {
+                this.cleared = cleared;
+                this.unchanged = unchanged;
+                this.value = value;
+            }
+        }
 }


### PR DESCRIPTION
…readContextConfig and NamedInstance.

Leverages CDI's `AnnotationLiteral` to implement helper classes for inline annotation creation.
Includes default instances for config annotations.