### PR TITLE
Fix CDI examples in JavaDoc only

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -40,12 +40,14 @@ import java.lang.annotation.Target;
  * <pre><code> &commat;Inject &commat;NamedInstance("exec1") &commat;ManagedExecutorConfig(maxAsync=5)
  * ManagedExecutor executor;
  *
- * int doSomething(&commat;Inject &commat;NamedInstance("exec1") ManagedExecutor exec) {
- *     ...
+ * &commat;Inject
+ * void setCompletableFuture(&commat;NamedInstance("exec1") ManagedExecutor exec) {
+ *     completableFuture = exec.newIncompleteFuture();
  * }
  *
- * int doSomethingElse(&commat;Inject &commat;NamedInstance("exec1") ManagedExecutor exec) {
- *     ...
+ * &commat;Inject
+ * void setCompletionStage(&commat;NamedInstance("exec1") ManagedExecutor exec) {
+ *     completionStage = exec.supplyAsync(supplier);
  * }
  * </code></pre>
  *

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -40,12 +40,14 @@ import java.lang.annotation.Target;
  * <pre><code> &commat;Inject &commat;NamedInstance("tc1") &commat;ThreadContextConfig({ ThreadContext.CDI, ThreadContext.APPLICATION })
  * ThreadContext threadContext1;
  *
- * void doSomething(&commat;Inject &commat;NamedInstance("tc1") ThreadContext contextPropagator) {
- *     ...
+ * &commat;Inject
+ * void setTask(&commat;NamedInstance("tc1") ThreadContext contextPropagator) {
+ *     task = contextPropagator.contextualTask(...);
  * }
  *
- * void doSomethingElse(&commat;Inject &commat;NamedInstance("tc1") ThreadContext contextPropagator) {
- *     ...
+ * &commat;Inject
+ * void setContextSnapshot(&commat;NamedInstance("tc1") ThreadContext contextPropagator) {
+ *     contextSnapshot = contextPropagator.currentContextExecutor();
  * }
  * </code></pre>
  *


### PR DESCRIPTION
There has been some discussion that the spec doc updates I added under #53 may be unwanted, in which case we still need a pull to fix the broken CDI examples that I found in the ManagedExecutorConfig/ThreadContextConfig JavaDoc.  I'm opening this pull for that.  It will only be needed if #53 is discarded.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>