### PR TITLE
Correct apache-rat-plugin now to blow up due to its own file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.12</version>
+                <version>0.13</version>
                 <executions>
                     <execution>
                         <id>rat-check</id>
@@ -189,7 +189,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/*.svg</exclude>
-                        <exclude>**/target</exclude>
+                        <exclude>**/target/*</exclude>
                         <exclude>.travis.yml.*</exclude>
                         <exclude>bnd.bnd</exclude>
                         <exclude>*.log</exclude>


### PR DESCRIPTION
When running `mvn clean install` the `rats` plugin blows up because it finds self-created text file with summary of license checks under spec/target and deems it incorrect.
I have adapted the exclusion list to ignore contents of target folders for when checking licenses.

I have also updated the plugin to its latest version while at it.