### PR TITLE
create some fake thread context types for TCK tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/TckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/TckTest.java
@@ -18,10 +18,22 @@
  */
 package org.eclipse.microprofile.concurrency.tck;
 
+import static org.eclipse.microprofile.concurrency.tck.contexts.priority.spi.ThreadPriorityContextProvider.THREAD_PRIORITY;
+
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
+import org.eclipse.microprofile.concurrency.tck.contexts.buffer.spi.BufferContextProvider;
+import org.eclipse.microprofile.concurrency.tck.contexts.label.Label;
+import org.eclipse.microprofile.concurrency.tck.contexts.label.spi.LabelContextProvider;
+import org.eclipse.microprofile.concurrency.tck.contexts.priority.spi.ThreadPriorityContextProvider;
+import org.eclipse.microprofile.concurrent.ThreadContext;
 import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -30,14 +42,94 @@ public class TckTest extends Arquillian {
 
     @Deployment
     public static WebArchive createDeployment() {
+        // build a JAR that provides fake 'ThreadPriority' context type
+        JavaArchive threadPriorityContextProvider = ShrinkWrap.create(JavaArchive.class, "threadPriorityContext.jar")
+                .addPackage(ThreadPriorityContextProvider.class.getPackage().getName())
+                .addAsServiceProvider(ThreadContextProvider.class, ThreadPriorityContextProvider.class);
+
+        // build a JAR that provides two fake context types: 'Buffer' and 'Label'
+        JavaArchive multiContextProvider = ShrinkWrap.create(JavaArchive.class, "bufferAndLabelContext.jar")
+                .addPackage(Buffer.class.getPackage().getName())
+                .addPackage(BufferContextProvider.class.getPackage().getName())
+                .addPackage(Label.class.getPackage().getName())
+                .addPackage(LabelContextProvider.class.getPackage().getName())
+                .addAsServiceProvider(ThreadContextProvider.class, BufferContextProvider.class, LabelContextProvider.class);
+
         return ShrinkWrap.create(WebArchive.class, TckTest.class.getSimpleName() + ".war")
-        .addClass(TckTest.class);
+                .addClass(TckTest.class)
+                .addAsLibraries(threadPriorityContextProvider, multiContextProvider);
+    }
+
+    @Test
+    public void builderForThreadContextIsProvided() {
+        Assert.assertNotNull(ThreadContext.builder(),
+                "MicroProfile Concurrency implementation does not provide a ThreadContext builder");
     }
 
     @Test
     public void providerSet() {
         ConcurrencyProvider provider = ConcurrencyProvider.instance();
-        Assert.assertNotNull(provider, "Provider is set");
+        Assert.assertNotNull(provider, "ConcurrencyProvider is not set");
     }
 
+    /**
+     * Verify that the MicroProfile Concurrency implementation finds third-party thread context providers
+     * that are made available to the ServiceLoader, allows their configuration via the ThreadContext builder,
+     * and correctly captures & propagates or clears these thread context types per the builder configuration.
+     * Subsequently verify that the MicroProfile Concurrency implementation properly restores thread context
+     * after the contextual action completes.
+     */
+    @Test
+    public void thirdPartyContextProvidersAreIncludedInThreadContext() {
+        ThreadContext labelAndPriorityContext = ThreadContext.builder()
+                .propagated(THREAD_PRIORITY, Label.CONTEXT_NAME)
+                .cleared(Buffer.CONTEXT_NAME)
+                .unchanged(ThreadContext.ALL_REMAINING)
+                .build();
+
+        int originalPriority = Thread.currentThread().getPriority();
+        int priorityA = originalPriority == 3 ? 2 : 3; // a non-default value
+        int priorityB = priorityA - 1; // a different non-default value
+        try {
+            // Set non-default values
+            Buffer.get().append("test-buffer-content-A");
+            Label.set("test-label-A");
+            Thread.currentThread().setPriority(priorityA);
+
+            Supplier<Integer> contextualSupplier = labelAndPriorityContext.contextualSupplier(() -> {
+                Assert.assertEquals(Buffer.get().toString(), "", "Context type that is configured to be cleared was not cleared");
+                Assert.assertEquals(Label.get(), "test-label-A", "Context type was not propagated to contextual action");
+                return Thread.currentThread().getPriority();
+            });
+
+            // Alter the values again
+            Buffer.get().append("-and-B");
+            Label.set("test-label-B");
+            Thread.currentThread().setPriority(priorityB);
+
+            // The contextual action runs with previously captured Label/ThreadPriority context, and with cleared Buffer context
+            int priority = contextualSupplier.get();
+
+            Assert.assertEquals(priority, priorityA, "Context type was not propagated to contextual action");
+
+            // The contextual action and its associated thread context snapshot is reusable
+            priority = contextualSupplier.get();
+
+            Assert.assertEquals(priority, priorityA, "Context type was not propagated to contextual action");
+
+            // Has context been properly restored after the contextual operation(s)?
+            Assert.assertEquals(Buffer.get().toString(), "test-buffer-content-A-and-B",
+                    "Previous context was not restored after context was cleared for contextual action");
+            Assert.assertEquals(Label.get(), "test-label-B",
+                    "Previous context (Label) was not restored after context was propagated for contextual action");
+            Assert.assertEquals(Thread.currentThread().getPriority(), priorityB,
+                    "Previous context (ThreadPriority) was not restored after context was propagated for contextual action");
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+            Thread.currentThread().setPriority(originalPriority);
+        }
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/Buffer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/Buffer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.buffer;
+
+/**
+ * This is a fake context type that is created by the test suite.
+ * It associates a StringBuffer with the current thread, accessible via the get/set methods of this class.
+ */
+public class Buffer {
+    public static final String CONTEXT_NAME = "Buffer";
+
+    private static ThreadLocal<StringBuffer> context = ThreadLocal.withInitial(() -> new StringBuffer());
+
+    // use static methods instead of constructing instance
+    private Buffer() {
+    }
+
+    public static StringBuffer get() {
+        return context.get();
+    }
+
+    public static void set(StringBuffer buffer) {
+        context.set(buffer == null ? new StringBuffer() : buffer);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.buffer.spi;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * This is a fake context type that is created by the test suite.
+ * It associates a StringBuffer with the current thread, accessible via
+ * the static get/set operations of the BufferContext class.
+ */
+public class BufferContextProvider implements ThreadContextProvider {
+    /**
+     * Buffer context is considered cleared by associating a new empty StringBuffer with the thread.
+     */
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new BufferContextSnapshot(new StringBuffer());
+    }
+
+    /**
+     * Save the buffer instance that is associated with the current thread.
+     */
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new BufferContextSnapshot(Buffer.get());
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return Buffer.CONTEXT_NAME;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextRestorer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextRestorer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.buffer.spi;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+
+/**
+ * Restores a buffer context that was saved upon creation.
+ */
+public class BufferContextRestorer implements ThreadContextController {
+    private StringBuffer bufferToRestore = Buffer.get();
+    private AtomicBoolean restored = new AtomicBoolean();
+
+    /**
+     * Restore the buffer context that was saved upon construction of this instance.
+     */
+    @Override
+    public void endContext() {
+        if (restored.compareAndSet(false, true)) {
+            Buffer.set(bufferToRestore);
+        }
+        else {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextSnapshot.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextSnapshot.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.buffer.spi;
+
+import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Represents a saved 'buffer' instance.
+ */
+public class BufferContextSnapshot implements ThreadContextSnapshot {
+    private final StringBuffer buffer;
+
+    BufferContextSnapshot(StringBuffer buffer) {
+        this.buffer = buffer;
+    }
+
+    /**
+     * Apply the requested buffer context to the current thread,
+     * first storing a copying of the buffer that was previously associated with the thread,
+     * to later be restored via the returned ThreadContextController.
+     */
+    @Override
+    public ThreadContextController begin() {
+        ThreadContextController contextRestorer = new BufferContextRestorer();
+        Buffer.set(buffer);
+        return contextRestorer;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/label/Label.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/label/Label.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.label;
+
+/**
+ * This is a fake context type that is created by the test suite,
+ * which associates an immutable label (a String) with a thread. 
+ */
+public class Label {
+    public static final String CONTEXT_NAME = "Label";
+    private static ThreadLocal<String> context = ThreadLocal.withInitial(() -> "");
+
+    // use static methods instead of constructing instance
+    private Label() {
+    }
+
+    /**
+     * Get the current 'label' context.
+     */
+    public static String get() {
+        return context.get();
+    }
+
+    /**
+     * Set the current 'label' context.
+     */
+    public static void set(String label) {
+        context.set(label == null ? "" : label);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/label/spi/LabelContextProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/label/spi/LabelContextProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.label.spi;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.microprofile.concurrency.tck.contexts.label.Label;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * This is a fake all-in-one context provider that is created by the test suite.
+ * This context type captures/clears/propagates/restores an immutable label (a String) that is associated with a thread. 
+ */
+public class LabelContextProvider implements ThreadContextProvider {
+    /**
+     * Cleared context is the empty string.
+     */
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return snapshot("");
+    }
+
+    /**
+     * Save the current context.
+     */
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return snapshot(Label.get());
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return Label.CONTEXT_NAME;
+    }
+
+    /**
+     * Construct a snapshot of context for the specified 'label'
+     */
+    private ThreadContextSnapshot snapshot(String label) {
+        return () -> {
+            String labelToRestore = Label.get();
+            AtomicBoolean restored = new AtomicBoolean();
+
+            // Construct an instance that restores the previous context that was on the thread
+            // prior to applying the specified 'label' as the new context.
+            ThreadContextController contextRestorer = () -> {
+                if (restored.compareAndSet(false, true)) {
+                    Label.set(labelToRestore);
+                }
+                else {
+                    throw new IllegalStateException();
+                }
+            };
+
+            Label.set(label);
+            return contextRestorer;
+        };
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/priority/spi/ThreadPriorityContextProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/priority/spi/ThreadPriorityContextProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.priority.spi;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * This is an example context type that is created by the test suite.
+ * This context type captures/clears/propagates/restores thread priority (java.lang.Thread.get/setPriority). 
+ * This is chosen, not because it is useful in any way, but because the concept of thread priority is simple,
+ * well understood, and already built into Java.
+ */
+public class ThreadPriorityContextProvider implements ThreadContextProvider {
+    public static final String THREAD_PRIORITY = "ThreadPriority";
+
+    /**
+     * Thread priority context is considered cleared by resetting to normal priority (Thread.NORM_PRIORITY).
+     */
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new ThreadPrioritySnapshot(Thread.NORM_PRIORITY);
+    }
+
+    /**
+     * Save the current thread priority.
+     */
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new ThreadPrioritySnapshot(Thread.currentThread().getPriority());
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return THREAD_PRIORITY;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/priority/spi/ThreadPrioritySnapshot.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/priority/spi/ThreadPrioritySnapshot.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.concurrency.tck.contexts.priority.spi;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Represents a saved copy of 'thread priority' context.
+ */
+public class ThreadPrioritySnapshot implements ThreadContextSnapshot {
+    private final int priority;
+
+    ThreadPrioritySnapshot(int priority) {
+        this.priority = priority;
+    }
+
+    /**
+     * Apply the saved thread priority to the current thread, but
+     * first storing a copying of the thread priority that was previously on the thread
+     * so that the previous thread priority can later be restored via the returned
+     * ThreadContextController.
+     */
+    @Override
+    public ThreadContextController begin() {
+        Thread thread = Thread.currentThread();
+        int priorityToRestore = thread.getPriority();
+        AtomicBoolean restored = new AtomicBoolean();
+
+        ThreadContextController contextRestorer = () -> {
+            if (restored.compareAndSet(false, true)) {
+                thread.setPriority(priorityToRestore);
+            }
+            else {
+                throw new IllegalStateException();
+            }
+        };
+
+        thread.setPriority(priority);
+
+        return contextRestorer;
+    }
+}


### PR DESCRIPTION
Create some fake thread context types for the TCK tests and use them to write a basic test confirming that third-party thread context providers which are made available via the ServiceLoader are found by the MicroProfile Concurrency implementation and used to capture/propagated/clear/restore thread context per the configuration that is supplied to the thread context builder.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>