### PR TITLE
TCK tests for contextual proxies

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -20,6 +20,16 @@ package org.eclipse.microprofile.concurrency.tck;
 
 import static org.eclipse.microprofile.concurrency.tck.contexts.priority.spi.ThreadPriorityContextProvider.THREAD_PRIORITY;
 
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
@@ -36,8 +46,44 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 
 public class ThreadContextTest extends Arquillian {
+    /**
+     * Maximum tolerated wait for an asynchronous operation to complete.
+     * This is important to ensure that tests don't hang waiting for asynchronous operations to complete.
+     * Normally these sort of operations will complete in tiny fractions of a second, but we are specifying
+     * an extremely generous value here to allow for the widest possible variety of test execution environments.
+     */
+    private static final long MAX_WAIT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    /**
+     * Pool of unmanaged threads (not context-aware) that can be used by tests. 
+     */
+    private ExecutorService unmanagedThreads;
+
+    @AfterClass
+    public void after() {
+        unmanagedThreads.shutdownNow();
+    }
+
+    @AfterMethod
+    public void afterMethod(Method m) {
+        System.out.println("<<< END ThreadContextTest." + m.getName());
+    }
+
+    @BeforeClass
+    public void before() {
+        unmanagedThreads = Executors.newFixedThreadPool(5);
+    }
+
+    @BeforeMethod
+    public void beforeMethod(Method m) {
+        System.out.println(">>> BEGIN ThreadContextTest." + m.getName());
+    }
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -60,7 +106,418 @@ public class ThreadContextTest extends Arquillian {
     @Test
     public void builderForThreadContextIsProvided() {
         Assert.assertNotNull(ThreadContext.builder(),
-                "MicroProfile Concurrency implementation does not provide a ThreadContext builder");
+                "MicroProfile Concurrency implementation does not provide a ThreadContext builder.");
+    }
+
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualConsumer
+     * method can be used to wrap a BiConsumer instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the BiConsumer accept method runs. This test case aligns with use case of
+     * supplying a contextual BiConsumer to a completion stage that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualBiConsumerRunsWithContext() throws InterruptedException {
+        ThreadContext bufferContext = ThreadContext.builder()
+                .propagated(Buffer.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
+                .build();
+
+        try {
+            // Set non-default values
+            Buffer.get().append("contextualBiConsumer-test-buffer");
+            Label.set("contextualBiConsumer-test-label");
+
+            // To avoid the possibility that CompletableFuture.get might cause the action to run
+            // on the current thread, which would bypass the intent of testing context propagation,
+            // use a countdown latch to independently wait for completion.
+            CountDownLatch completed = new CountDownLatch(1);
+
+            // CompletableFuture from Java SE is intentionally used here to avoid the context
+            // propagation guarantees of MicroProfile Concurrency's ManagedExecutor.
+            // This ensures we are testing that MicroProfile Concurrency's ThreadContext is
+            // doing the work to propagate the context rather than getting it from a
+            // ManagedExecutor.
+            CompletableFuture<String> stage1a = CompletableFuture.supplyAsync(() -> "supplied-value-A");
+            CompletableFuture<String> stage1b = CompletableFuture.supplyAsync(() -> "supplied-value-B");
+
+            CompletableFuture<Void> stage2 = stage1a.thenAcceptBothAsync(stage1b,
+                    bufferContext.contextualConsumer((a, b) -> {
+                        Assert.assertEquals(a, "supplied-value-A",
+                                "First value supplied to BiConsumer was lost or altered.");
+
+                        Assert.assertEquals(b, "supplied-value-B",
+                                "Second value supplied to BiConsumer was lost or altered.");
+
+                        Assert.assertEquals(Buffer.get().toString(), "contextualBiConsumer-test-buffer",
+                                "Context type was not propagated to contextual action.");
+
+                        Assert.assertEquals(Label.get(), "",
+                                "Context type that is configured to be cleared was not cleared.");
+                    }),
+                    unmanagedThreads);
+
+            stage2.whenComplete((unused, failure) -> completed.countDown());
+
+            Assert.assertTrue(completed.await(MAX_WAIT_NS, TimeUnit.NANOSECONDS),
+                    "Completable future did not finish in a reasonable amount of time.");
+
+            // Force errors, if any, to be reported
+            stage2.join();
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+        }
+    }
+
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualFunction
+     * method can be used to wrap a BiFunction instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the BiFunction apply method runs. This test case aligns with use case of
+     * supplying a contextual BiFunction to a completion stage that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualBiFunctionRunsWithContext()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ThreadContext labelContext = ThreadContext.builder()
+                .propagated(Label.CONTEXT_NAME)
+                .build();
+
+        try {
+            // Set non-default values
+            Buffer.get().append("contextualBiFunction-test-buffer");
+            Label.set("contextualBiFunction-test-label");
+
+            // CompletableFuture from Java SE is intentionally used here to avoid the context
+            // propagation guarantees of MicroProfile Concurrency's ManagedExecutor.
+            // This ensures we are testing that MicroProfile Concurrency's ThreadContext is
+            // doing the work to propagate the context rather than getting it from a
+            // ManagedExecutor.
+            CompletableFuture<Integer> stage1a = new CompletableFuture<Integer>();
+            CompletableFuture<Integer> stage1b = new CompletableFuture<Integer>();
+
+            CompletableFuture<Integer> stage2 = stage1a.thenCombine(stage1b,
+                    labelContext.contextualFunction((a, b) -> {
+                        Assert.assertEquals(a, Integer.valueOf(10),
+                                "First value supplied to BiFunction was lost or altered.");
+
+                        Assert.assertEquals(b, Integer.valueOf(20),
+                                "Second value supplied to BiFunction was lost or altered.");
+
+                        Assert.assertEquals(Label.get(), "contextualBiFunction-test-label",
+                                "Context type was not propagated to contextual action.");
+
+                        Assert.assertEquals(Buffer.get().toString(), "",
+                                "Context type that is configured to be cleared was not cleared.");
+
+                        return a + b;
+                    }));
+
+            Future<Integer> future = unmanagedThreads.submit(() -> {
+                stage1a.complete(10);
+                stage1b.complete(20);
+                return stage2.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS);
+            });
+
+            Assert.assertEquals(future.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS), Integer.valueOf(30),
+                    "Result of BiFunction was lost or altered.");
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+        }
+    }
+
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualCallable
+     * method can be used to wrap a Callable instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the Callable call method runs. This test case aligns with use case of
+     * supplying a contextual Callable to an unmanaged executor that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualCallableRunsWithContext()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ThreadContext priorityContext = ThreadContext.builder()
+                .propagated(THREAD_PRIORITY)
+                .build();
+
+        int originalPriority = Thread.currentThread().getPriority();
+        try {
+            // Set non-default values
+            int newPriority = originalPriority == 4 ? 3 : 4;
+            Thread.currentThread().setPriority(newPriority);
+            Buffer.get().append("contextualCallable-test-buffer");
+            Label.set("contextualCallable-test-label");
+
+            Future<Integer> future = unmanagedThreads.submit(priorityContext.contextualCallable(() -> {
+                Assert.assertEquals(Buffer.get().toString(), "",
+                        "Context type (Buffer) that is configured to be cleared was not cleared.");
+
+                Assert.assertEquals(Label.get(), "",
+                        "Context type (Label) that is configured to be cleared was not cleared.");
+
+                return Thread.currentThread().getPriority();
+            }));
+
+            Assert.assertEquals(future.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS), Integer.valueOf(newPriority),
+                    "Callable returned incorrect value.");
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+            Thread.currentThread().setPriority(originalPriority);
+        }
+    }
+
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualConsumer
+     * method can be used to wrap a Consumer instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the Consumer accept method runs. This test case aligns with use case of
+     * supplying a contextual Consumer to a completion stage that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualConsumerRunsWithContext() throws InterruptedException {
+        ThreadContext labelContext = ThreadContext.builder()
+                .propagated(Label.CONTEXT_NAME)
+                .build();
+
+        try {
+            // Set non-default values
+            Buffer.get().append("contextualConsumer-test-buffer");
+            Label.set("contextualConsumer-test-label");
+
+            // To avoid the possibility that CompletableFuture.get might cause the action to run
+            // on the current thread, which would bypass the intent of testing context propagation,
+            // use a countdown latch to independently wait for completion.
+            CountDownLatch completed = new CountDownLatch(1);
+
+            // Similarly, the initial stage is left incomplete until after thenAccept adds the
+            // action, to eliminate the possibility that this triggers the action to run inline.
+
+            // CompletableFuture from Java SE is intentionally used here to avoid the context
+            // propagation guarantees of MicroProfile Concurrency's ManagedExecutor.
+            // This ensures we are testing that MicroProfile Concurrency's ThreadContext is
+            // doing the work to propagate the context rather than getting it from a 
+            // ManagedExecutor.
+            CompletableFuture<String> stage1 = new CompletableFuture<String>();
+            CompletableFuture<Void> stage2 = stage1
+                    .thenApplyAsync(unused -> "supply-to-consumer", unmanagedThreads)
+                    .thenAccept(labelContext.contextualConsumer(s -> {
+                        Assert.assertEquals(s, "supply-to-consumer",
+                                "Value supplied to Consumer was lost or altered.");
+
+                        Assert.assertEquals(Buffer.get().toString(), "",
+                                "Context type that is configured to be cleared was not cleared.");
+
+                        Assert.assertEquals(Label.get(), "contextualConsumer-test-label",
+                                "Context type was not propagated to contextual action.");
+                    }));
+
+            stage1.complete("unblock");
+
+            stage2.whenComplete((unused, failure) -> completed.countDown());
+
+            Assert.assertTrue(completed.await(MAX_WAIT_NS, TimeUnit.NANOSECONDS),
+                    "Completable future did not finish in a reasonable amount of time.");
+
+            // Force errors, if any, to be reported
+            stage2.join();
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+        }
+    }
+
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualFunction
+     * method can be used to wrap a Function instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the Function apply method runs. This test case aligns with use case of
+     * supplying a contextual Function to a completion stage that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualFunctionRunsWithContext()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ThreadContext bufferContext = ThreadContext.builder()
+                .propagated(Buffer.CONTEXT_NAME)
+                .build();
+
+        try {
+            // Set non-default values
+            Buffer.get().append("contextualFunction-test-buffer");
+            Label.set("contextualFunction-test-label");
+
+            // Reusable contextual function
+            Function<Long, Long> contextualFunction = bufferContext.contextualFunction(i -> {
+                Buffer.get().append("-" + i);
+
+                Assert.assertEquals(Label.get(), "",
+                        "Context type that is configured to be cleared was not cleared.");
+                
+                return i * 2L;
+            });
+
+            // CompletableFuture from Java SE is intentionally used here to avoid the context
+            // propagation guarantees of MicroProfile Concurrency's ManagedExecutor.
+            // This ensures we are testing that MicroProfile Concurrency's ThreadContext is
+            // doing the work to propagate the context rather than getting it from a
+            // ManagedExecutor.
+            CompletableFuture<Long> stage1 = new CompletableFuture<Long>();
+
+            CompletableFuture<Long> stage2 = stage1
+                    .thenApply(contextualFunction)
+                    .thenApply(i -> i + 10)
+                    .thenApply(contextualFunction);
+
+            Future<Long> future = unmanagedThreads.submit(() -> {
+                stage1.complete(75L);
+                return stage2.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS);
+            });
+
+            Assert.assertEquals(future.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS), Long.valueOf(320),
+                    "Result of Function was lost or altered.");
+
+            // Verify updates written to the 'buffer' context from the contextual actions
+            Assert.assertEquals(Buffer.get().toString(), "contextualFunction-test-buffer-75-160",
+                    "Context not propagated or incorrectly propagated to contextualFunctions.");
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+        }
+    }
+
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualRunnable
+     * method can be used to wrap a Runnable instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the Runnable run method runs. This test case aligns with use case of
+     * supplying a contextual Runnable to a completion stage that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualRunnableRunsWithContext()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ThreadContext priorityAndBufferContext = ThreadContext.builder()
+                .propagated(THREAD_PRIORITY, Buffer.CONTEXT_NAME)
+                .build();
+
+        int originalPriority = Thread.currentThread().getPriority();
+        try {
+            // Set non-default values
+            int newPriority = originalPriority == 2 ? 1 : 2;
+            Thread.currentThread().setPriority(newPriority);
+            Buffer.get().append("contextualRunnable-test-buffer");
+            Label.set("contextualRunnable-test-label");
+
+            // Reusable contextual Runnable
+            Runnable contextualRunnable = priorityAndBufferContext.contextualRunnable(() -> {
+                int priority = Thread.currentThread().getPriority();
+
+                Buffer.get().append("-" + priority);
+
+                Assert.assertEquals(Label.get(), "",
+                        "Context type that is configured to be cleared was not cleared.");
+            });
+
+            Thread.currentThread().setPriority(originalPriority);
+
+            // CompletableFuture from Java SE is intentionally used here to avoid the context
+            // propagation guarantees of MicroProfile Concurrency's ManagedExecutor.
+            // This ensures we are testing that MicroProfile Concurrency's ThreadContext is
+            // doing the work to propagate the context rather than getting it from a
+            // ManagedExecutor.
+            CompletableFuture<Void> stage1 = new CompletableFuture<Void>();
+
+            CompletableFuture<Void> stage2 = stage1
+                    .thenRun(contextualRunnable)
+                    .thenRun(() -> Buffer.get().append("-non-contextual-runnable"))
+                    .thenRun(contextualRunnable);
+
+            Future<Void> future = unmanagedThreads.submit(() -> {
+                stage1.complete(null);
+                stage2.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS);
+                return null;
+            });
+
+            future.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS);
+
+            // Verify updates written to the 'buffer' context from the contextual actions
+            Assert.assertEquals(Buffer.get().toString(), "contextualRunnable-test-buffer-" + newPriority + "-" + newPriority,
+                    "Context not propagated or incorrectly propagated to contextualFunctions.");
+        }
+        finally {
+            // Restore original values
+            Thread.currentThread().setPriority(originalPriority);
+            Buffer.set(null);
+            Label.set(null);
+        }
+    }
+    /**
+     * Verify that the MicroProfile Concurrency ThreadContext implementation's contextualSupplier
+     * method can be used to wrap a Supplier instance with the context that is captured from the
+     * current thread per the configuration of the ThreadContext builder, and that the context is
+     * applied when the Supplier get method runs. This test case aligns with use case of
+     * supplying a contextual Supplier to a completion stage that is otherwise not context-aware.
+     */
+    @Test
+    public void contextualSupplierRunsWithContext() throws InterruptedException {
+        ThreadContext bufferContext = ThreadContext.builder()
+                .propagated(Buffer.CONTEXT_NAME)
+                .unchanged(ThreadContext.APPLICATION)
+                .build();
+
+        try {
+            // Set non-default values
+            Buffer.get().append("contextualSupplier-test-buffer");
+            Label.set("contextualSupplier-test-label");
+
+            // To avoid the possibility that CompletableFuture.get might cause the action to run
+            // on the current thread, which would bypass the intent of testing context propagation,
+            // use a countdown latch to independently wait for completion.
+            CountDownLatch completed = new CountDownLatch(1);
+
+            // CompletableFuture from Java SE is intentionally used here to avoid the context
+            // propagation guarantees of MicroProfile Concurrency's ManagedExecutor.
+            // This ensures we are testing that MicroProfile Concurrency's ThreadContext is
+            // doing the work to propagate the context rather than getting it from a 
+            // ManagedExecutor.
+            CompletableFuture<String> stage1 = CompletableFuture.supplyAsync(
+                    bufferContext.contextualSupplier(() -> {
+                        Assert.assertEquals(Label.get(), "",
+                                "Context type that is configured to be cleared was not cleared.");
+
+                        String bufferContents = Buffer.get().toString();
+                        Assert.assertEquals(bufferContents, "contextualSupplier-test-buffer",
+                                "Context type was not propagated to contextual action.");
+                        return bufferContents;
+                    }));
+
+            stage1.whenComplete((unused, failure) -> completed.countDown());
+
+            Assert.assertTrue(completed.await(MAX_WAIT_NS, TimeUnit.NANOSECONDS),
+                    "Completable future did not finish in a reasonable amount of time.");
+
+            // Force errors, if any, to be reported
+            String result = stage1.join();
+
+            Assert.assertEquals(result, "contextualSupplier-test-buffer",
+                    "Supplier result was lost or altered.");
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
+        }
     }
 
     /**
@@ -88,8 +545,8 @@ public class ThreadContextTest extends Arquillian {
             Thread.currentThread().setPriority(priorityA);
 
             Supplier<Integer> contextualSupplier = labelAndPriorityContext.contextualSupplier(() -> {
-                Assert.assertEquals(Buffer.get().toString(), "", "Context type that is configured to be cleared was not cleared");
-                Assert.assertEquals(Label.get(), "test-label-A", "Context type was not propagated to contextual action");
+                Assert.assertEquals(Buffer.get().toString(), "", "Context type that is configured to be cleared was not cleared.");
+                Assert.assertEquals(Label.get(), "test-label-A", "Context type was not propagated to contextual action.");
                 return Thread.currentThread().getPriority();
             });
 
@@ -101,20 +558,20 @@ public class ThreadContextTest extends Arquillian {
             // The contextual action runs with previously captured Label/ThreadPriority context, and with cleared Buffer context
             int priority = contextualSupplier.get();
 
-            Assert.assertEquals(priority, priorityA, "Context type was not propagated to contextual action");
+            Assert.assertEquals(priority, priorityA, "Context type was not propagated to contextual action.");
 
             // The contextual action and its associated thread context snapshot is reusable
             priority = contextualSupplier.get();
 
-            Assert.assertEquals(priority, priorityA, "Context type was not propagated to contextual action");
+            Assert.assertEquals(priority, priorityA, "Context type was not propagated to contextual action.");
 
             // Has context been properly restored after the contextual operation(s)?
             Assert.assertEquals(Buffer.get().toString(), "test-buffer-content-A-and-B",
-                    "Previous context was not restored after context was cleared for contextual action");
+                    "Previous context was not restored after context was cleared for contextual action.");
             Assert.assertEquals(Label.get(), "test-label-B",
-                    "Previous context (Label) was not restored after context was propagated for contextual action");
+                    "Previous context (Label) was not restored after context was propagated for contextual action.");
             Assert.assertEquals(Thread.currentThread().getPriority(), priorityB,
-                    "Previous context (ThreadPriority) was not restored after context was propagated for contextual action");
+                    "Previous context (ThreadPriority) was not restored after context was propagated for contextual action.");
         }
         finally {
             // Restore original values

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextProvider.java
@@ -35,7 +35,7 @@ public class BufferContextProvider implements ThreadContextProvider {
      */
     @Override
     public ThreadContextSnapshot clearedContext(Map<String, String> props) {
-        return new BufferContextSnapshot(new StringBuffer());
+        return new BufferContextSnapshot(null);
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextRestorer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextRestorer.java
@@ -42,4 +42,12 @@ public class BufferContextRestorer implements ThreadContextController {
             throw new IllegalStateException();
         }
     }
+
+    // For easier debug
+    @Override
+    public String toString() {
+        return "BufferContextRestorer@" + Integer.toHexString(System.identityHashCode(this)) +
+                " for StringBuffer@" + Integer.toHexString(System.identityHashCode(bufferToRestore)) +
+               ": " + bufferToRestore.toString();
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextSnapshot.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/buffer/spi/BufferContextSnapshot.java
@@ -40,7 +40,20 @@ public class BufferContextSnapshot implements ThreadContextSnapshot {
     @Override
     public ThreadContextController begin() {
         ThreadContextController contextRestorer = new BufferContextRestorer();
-        Buffer.set(buffer);
+        Buffer.set(buffer == null ? new StringBuffer() : buffer);
         return contextRestorer;
+    }
+
+    // For easier debug
+    @Override
+    public String toString() {
+        String s = "BufferContextSnapshot@" + Integer.toHexString(System.identityHashCode(this));
+        if (buffer == null) {
+            s += " CLEARED";
+        }
+        else {
+            s += " for StringBuffer@" + Integer.toHexString(System.identityHashCode(buffer)) + ": " + buffer.toString();
+        }
+        return s;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/priority/spi/ThreadPrioritySnapshot.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/contexts/priority/spi/ThreadPrioritySnapshot.java
@@ -58,4 +58,10 @@ public class ThreadPrioritySnapshot implements ThreadContextSnapshot {
 
         return contextRestorer;
     }
+
+    // For easier debug
+    @Override
+    public String toString() {
+        return "ThreadPrioritySnapshot@" + Integer.toHexString(System.identityHashCode(this)) + ": " + priority;
+    }
 }


### PR DESCRIPTION
Write TCK tests to cover context propagation to contextual proxies. This includes,
contextualCallable
contextualBiConsumer
contextualBiFunction
contextualConsumer
contextualFunction
contextualRunnable
contextualSupplier