### PR TITLE
fix checkstyle failures causing build to fail

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -318,7 +318,8 @@ public class ManagedExecutorTest extends Arquillian {
             .maxQueued(-1)
             .build();
             Assert.fail("ManagedExecutor.Builder.build() should throw an IllegalStateException for set overlap between propagated and cleared");
-        } catch (IllegalStateException ISE) {
+        }
+        catch (IllegalStateException ISE) {
             // test passes
         }
 
@@ -330,7 +331,8 @@ public class ManagedExecutorTest extends Arquillian {
             .maxQueued(-1)
             .build();
             Assert.fail("ManagedExecutor.Builder.build() should throw an IllegalStateException for a nonexistent thread context type");
-        } catch (IllegalStateException ISE) {
+        }
+        catch (IllegalStateException ISE) {
             // test passes
         }
 

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -602,7 +602,8 @@ public class ThreadContextTest extends Arquillian {
             .unchanged(THREAD_PRIORITY)
             .build();
             Assert.fail("ThreadContext.Builder.build() should throw an IllegalStateException for set overlap between propagated and cleared");
-        } catch (IllegalStateException ISE) {
+        }
+        catch (IllegalStateException ISE) {
             //expected.
         }
 


### PR DESCRIPTION
It looks like checkstyle is failing the build.  This is probably from one of the pulls (#69 or #70) that I merged earlier today. I must have overlooked those failures when merging.  Sorry about this.  In any case, I'll be merging this pull to fix them.

[ERROR] /Users/njr/lgit/microprofile-concurrency/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java:605:9: '}' at column 9 should be alone on a line. [RightCurly]
[ERROR] /Users/njr/lgit/microprofile-concurrency/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java:323:9: '}' at column 9 should be alone on a line. [RightCurly]
[ERROR] /Users/njr/lgit/microprofile-concurrency/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java:335:9: '}' at column 9 should be alone on a line. [RightCurly]

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>