### PR TITLE
Make sure we clear what we want cleared

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -1385,6 +1385,7 @@ public class ManagedExecutorTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(Label.CONTEXT_NAME)
                 .build();
 
         try {
@@ -1514,6 +1515,7 @@ public class ManagedExecutorTest extends Arquillian {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(1)
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(Buffer.CONTEXT_NAME)
                 .build();
 
         // Verify that maxAsync=1 is enforced by recording the thread id upon which

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -126,6 +126,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void completedFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(Label.CONTEXT_NAME)
                 .build();
 
         try {
@@ -228,6 +229,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void completedStageDependentStagesRunWithContext() throws InterruptedException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(Buffer.CONTEXT_NAME)
                 .build();
 
         try {
@@ -388,6 +390,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void failedFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(Label.CONTEXT_NAME)
                 .build();
 
         try {
@@ -785,6 +788,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void newIncompleteFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(Buffer.CONTEXT_NAME)
                 .build();
 
         try {
@@ -1123,6 +1127,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void runAsyncStageAndDependentStagesRunWithContext() throws ExecutionException, InterruptedException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(Buffer.CONTEXT_NAME)
                 .build();
 
         try {
@@ -1267,6 +1272,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void supplyAsyncStageAndDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(Label.CONTEXT_NAME)
                 .build();
 
         try {


### PR DESCRIPTION
This makes sure that we mark the contexts to clear, otherwise we're testing contexts for being cleared without reason.