### PR TITLE
Do not specify that tasks should be cancelled on executor shutdown ca…

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -109,7 +109,7 @@ public interface ManagedExecutor extends ExecutorService {
          *
          * <p>All created instances of {@link ManagedExecutor} are destroyed
          * when the application is stopped. The container automatically shuts down these
-         * managed executors and cancels their remaining actions/tasks.</p>
+         * managed executors.</p>
          *
          * @return new instance of {@link ManagedExecutor}.
          * @throws IllegalStateException for any of the following error conditions

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -82,10 +82,8 @@ public interface ThreadContext {
          *
          * <p>All created instances of {@link ThreadContext} are destroyed
          * when the application is stopped. The container automatically shuts down these
-         * {@link ThreadContext} instances, cancels their remaining
-         * <code>CompletableFuture</code>s and <code>CompletionStage</code>s, and
-         * and raises <code>IllegalStateException</code> to reject subsequent attempts
-         * to apply previously captured thread context.</p>
+         * {@link ThreadContext} instances and raises <code>IllegalStateException</code>
+         * to reject subsequent attempts to apply previously captured thread context.</p>
          *
          * @return new instance of {@link ThreadContext}.
          * @throws IllegalStateException for any of the following error conditions


### PR DESCRIPTION
…ll. Alter relevant TCKs. Fixes #78.

@njr-11 this removes the bits from docs that state anything about cancellation (which only regards after application exits hence has no value) and also changes the test.
Although I suspect this way it will break your implementation which actually has the cancelled state, right? What change would be safe and still make the test sensible? Asserting just `!isDone()`?