### PR TITLE
JavaDoc for cleared() methods should document the requirement to append ALL_REMAINING if not specified elsewhere

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -139,6 +139,10 @@ public interface ManagedExecutor extends ExecutorService {
          * that each action or task is able to independently start and end
          * its own transactional work.</p>
          *
+         * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
+         * set of cleared context if the {@link #propagated} set does not include
+         * {@link ThreadContext#ALL_REMAINING}.</p>
+         *
          * <p>Constants for specifying some of the core context types are provided
          * on {@link ThreadContext}. Other thread context types must be defined
          * by the specification that defines the context type or by a related

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -91,6 +91,10 @@ public @interface ManagedExecutorConfig {
      * end transactions of their choosing, to independently perform their
      * own transactional work, as needed.</p>
      *
+     * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
+     * set of cleared context if the {@link #propagated} set does not include
+     * {@link ThreadContext#ALL_REMAINING}.</p>
+     *
      * <p>Constants for specifying some of the core context types are provided
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -117,6 +117,10 @@ public interface ThreadContext {
          * that each action or task is able to independently start and end
          * its own transactional work.</p>
          *
+         * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
+         * set of cleared context if neither the {@link #propagated} set nor the
+         * {@link #unchanged} set include {@link ThreadContext#ALL_REMAINING}.</p>
+         *
          * <p>Constants for specifying some of the core context types are provided
          * on {@link ThreadContext}. Other thread context types must be defined
          * by the specification that defines the context type or by a related

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -86,6 +86,10 @@ public @interface ThreadContextConfig {
      * end transactions of their choosing, to independently perform their
      * own transactional work, as needed.</p>
      *
+     * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
+     * set of cleared context if neither the {@link #propagated} set nor the
+     * {@link #unchanged} set include {@link ThreadContext#ALL_REMAINING}.</p>
+     *
      * <p>Constants for specifying some of the core context types are provided
      * on {@link ThreadContext}. Other thread context types must be defined
      * by the specification that defines the context type or by a related


### PR DESCRIPTION
Pull fixes #80 

Update JavaDoc for cleared() methods on ManagedExecutor.Builder, ThreadContext.Builder, ManagedExecutorConfig, and ThreadContextConfig to document the requirement for ALL_REMAINING to be automatically appended when it is not specified on either the propagated or unchanged method.  

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>