### PR TITLE
write spec doc for integration with MP Config

### DIFF
--- a/spec/src/main/asciidoc/microprofile-concurrency.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-concurrency.asciidoc
@@ -43,6 +43,8 @@ include::builders.asciidoc[]
 
 include::cdi.asciidoc[]
 
+include::mpconfig.asciidoc[]
+
 include::examples.asciidoc[]
 
 include::contextproviders.asciidoc[]

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,11 +27,9 @@ Applications can use MicroProfile Config in the standard way to enable configura
 ----
 @Produces @ApplicationScoped @NamedInstance("executor1")
 ManagedExecutor createExecutor(
-  @ConfigProperty(name="exec1.maxAsync", defaultValue="5") Integer a,
-  @ConfigProperty(name="exec1.maxQueued", defaultValue="20") Integer q,
-  @ConfigProperty(name="exec1.cleared", defaultValue=ThreadContext.TRANSACTION) String[] c,
-  @ConfigProperty(name="exec1.propagated", defaultValue=ThreadContext.ALL_REMAINING) String[] p) {
-    return ManagedExecutor.builder().maxAsync(a).maxQueued(q).propagated(p).cleared(c).build();
+    @ConfigProperty(name="exec1.maxAsync", defaultValue="5") Integer a,
+    @ConfigProperty(name="exec1.maxQueued", defaultValue="20") Integer q) {
+    return ManagedExecutor.builder().maxAsync(a).maxQueued(q).build();
 }
 ----
 
@@ -80,7 +78,7 @@ org.eclipse.microprofile.example.MyBean.exec4.maxAsync=7
 
 Note that `org.eclipse.microprofile.example.MyBean.exec4.maxAsync` overrides the configuration of the instance that is produced for injection into `exec4`. This same instance is injected into `exec5` per the matching `@NamedInstance("executor4")` qualifier.  It is an error to specify `org.eclipse.microprofile.example.MyBean.exec5.maxAsync`, which will not apply to `exec5`.
 
-To override a configuration attribute of an instance that is produced for injection into a parameter, specify a MicroProfile Config property with the name equal to the fully qualified class name, method name, parameter name, and configuration attribute name, delimited by the `.` character.
+To override a configuration attribute of an instance that is produced for injection into a parameter, specify a MicroProfile Config property with its name equal to the fully qualified class name, method name, parameter number (starting at 1), and configuration attribute name, delimited by the `.` character.
 
 [source, java]
 ----
@@ -99,7 +97,7 @@ public class MyBean {
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean.createExecutor.exec.maxAsync=10
+org.eclipse.microprofile.example.MyBean.createExecutor.1.maxAsync=10
 ----
 
 Again, it would be wrong to specify `org.eclipse.microprofile.example.MyBean.exec6.maxAsync`, because the container does not produce a new instance for the `exec6` injection point. The container produces the new instance for the `exec` injection point, and matches that same instance for injection into `exec6` per the `@NamedInstance("executor6")` qualifier.

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[concurrencympconfig]]
+== Integration with MicroProfile Config
+
+If a MicroProfile Config implementation is available, MicroProfile Config can be used to override configuration attributes of `ManagedExecutor` and `ThreadContext`.  This is true of instances that are built by the application as well as those produced by the container for injection as CDI beans.  The former involves standard usage of MicroProfile Config.  The latter relies upon the convention of defining MicroProfile Config property names that correspond to the fully qualified name of the injection point for which the instance is produced.
+
+=== Application usage of MicroProfile Config
+
+Applications can use MicroProfile Config in the standard way to enable configuration attributes of the `ManagedExecutor` and `ThreadContext` builders to be overriden.  For example,
+
+[source, java]
+----
+@Produces @ApplicationScoped @NamedInstance("executor1")
+ManagedExecutor createExecutor(
+  @ConfigProperty(name="exec1.maxAsync", defaultValue="5") Integer a,
+  @ConfigProperty(name="exec1.maxQueued", defaultValue="20") Integer q,
+  @ConfigProperty(name="exec1.cleared", defaultValue=ThreadContext.TRANSACTION) String[] c,
+  @ConfigProperty(name="exec1.propagated", defaultValue=ThreadContext.ALL_REMAINING) String[] p) {
+    return ManagedExecutor.builder().maxAsync(a).maxQueued(q).propagated(p).cleared(c).build();
+}
+----
+
+MicroProfile Config can be used to override configuration attributes from the above example as follows,
+
+[source, text]
+----
+exec1.maxAsync=10
+exec1.propagated=Application,CDI
+exec1.cleared=Remaining
+----
+
+=== Container usage of MicroProfile Config
+
+The container produces an instance per unqualified `ManagedExecutor` injection point, which may optionally be annotated with the `@ManagedExecutorConfig` annotation to supply default configuration. The container also produces an instance per `ManagedExecutor` injection point that is annotated with both the `@ManagedExecutorConfig` annotation and the `@NamedInstance` qualifier. And likewise for `ThreadContext` and `@ThreadContextConfig`.
+
+In each of these cases, MicroProfile Config can be used to override the configuration of the instance that is produced by the container.
+
+To override a configuration attribute of an instance that is produced for injection into a field, specify a MicroProfile Config property with the name equal to the fully qualified class name, field name, and configuration attribute name, delimited by the `.` character.
+
+[source, java]
+----
+package org.eclipse.microprofile.example;
+...
+public class MyBean {
+    @Inject
+    ManagedExecutor exec2;
+
+    @Inject @ManagedExecutorConfig(maxAsync=3)
+    ManagedExecutor exec3;
+
+    @Inject @NamedInstance("executor4") @ManagedExecutorConfig(maxAsync=4)
+    ManagedExecutor exec4;
+
+    @Inject @NamedInstance("executor4")
+    ManagedExecutor exec5;
+}
+----
+
+[source, text]
+----
+org.eclipse.microprofile.example.MyBean.exec2.maxAsync=5
+org.eclipse.microprofile.example.MyBean.exec3.maxAsync=6
+org.eclipse.microprofile.example.MyBean.exec4.maxAsync=7
+----
+
+Note that `org.eclipse.microprofile.example.MyBean.exec4.maxAsync` overrides the configuration of the instance that is produced for injection into `exec4`. This same instance is injected into `exec5` per the matching `@NamedInstance("executor4")` qualifier.  It is an error to specify `org.eclipse.microprofile.example.MyBean.exec5.maxAsync`, which will not apply to `exec5`.
+
+To override a configuration attribute of an instance that is produced for injection into a parameter, specify a MicroProfile Config property with the name equal to the fully qualified class name, method name, parameter name, and configuration attribute name, delimited by the `.` character.
+
+[source, java]
+----
+package org.eclipse.microprofile.example;
+...
+public class MyBean {
+    @Produces @ApplicationScoped @NamedInstance("executor6")
+    ManagedExecutor createExecutor(@ManagedExecutorConfig(maxAsync=6) exec) {
+        return exec;
+    }
+
+    @Inject @NamedInstance("executor6")
+    ManagedExecutor exec6;
+}
+----
+
+[source, text]
+----
+org.eclipse.microprofile.example.MyBean.createExecutor.exec.maxAsync=10
+----
+
+Again, it would be wrong to specify `org.eclipse.microprofile.example.MyBean.exec6.maxAsync`, because the container does not produce a new instance for the `exec6` injection point. The container produces the new instance for the `exec` injection point, and matches that same instance for injection into `exec6` per the `@NamedInstance("executor6")` qualifier.

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -86,7 +86,7 @@ package org.eclipse.microprofile.example;
 ...
 public class MyBean {
     @Produces @ApplicationScoped @NamedInstance("executor6")
-    ManagedExecutor createExecutor(@ManagedExecutorConfig(maxAsync=6) exec) {
+    ManagedExecutor createExecutor(@ManagedExecutorConfig(maxAsync=6) ManagedExecutor exec) {
         return exec;
     }
 

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -132,7 +132,7 @@ The other injection points, `executor2` and `executor3`, share the same `Managed
 
 This specification defines a convention for defining properties in MicroProfile Config that override configuration attributes of `ManagedExecutor` and `ThreadContext` instances that are produced by the container. The convention for the property name is the fully qualified name of the injection point, with the `.` character as delimiter.
 
-The following example shows one injection point for `ManagedExecutor`, which is the `exec` parameter of the `setCompletableFuture` method, and another injection point for `ThreadContext`, which is the `appContextPropagator` field.
+The following example shows one injection point for `ManagedExecutor`, which is the first parameter of the `setCompletableFuture` method, and another injection point for `ThreadContext`, which is the `appContextPropagator` field.
 
 [source, java]
 ----
@@ -165,8 +165,8 @@ The following MicroProfile config properties could be used to override specific 
 
 [source, text]
 ----
-org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.exec.maxAsync=5
-org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.exec.maxQueued=20
+org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.1.maxAsync=5
+org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.1.maxQueued=20
 org.eclipse.microprofile.example.ExampleBean.appContextPropagator.cleared=Security,Transaction
 ----
 

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -128,6 +128,48 @@ The other injection points, `executor2` and `executor3`, share the same `Managed
     ManagedExecutor executor3;
 ----
 
+=== Integration with MicroProfile Config
+
+This specification defines a convention for defining properties in MicroProfile Config that override configuration attributes of `ManagedExecutor` and `ThreadContext` instances that are produced by the container. The convention for the property name is the fully qualified name of the injection point, with the `.` character as delimiter.
+
+The following example shows one injection point for `ManagedExecutor`, which is the `exec` parameter of the `setCompletableFuture` method, and another injection point for `ThreadContext`, which is the `appContextPropagator` field.
+
+[source, java]
+----
+package org.eclipse.microprofile.example;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.ThreadContextConfig;
+import java.util.concurrent.CompletableFuture;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ExampleBean {
+    CompletableFuture<Long> completableFuture;
+
+    @Inject
+    void setCompletableFuture(ManagedExecutor exec) {
+        completableFuture = exec.newIncompleteFuture();
+    }
+
+    @Inject @ThreadContextConfig(propagated = ThreadContext.APPLICATION,
+                                 cleared = ThreadContext.TRANSACTION,
+                                 unchanged = ThreadContext.ALL_REMAINING)
+    ThreadContext appContextPropagator;
+}
+----
+
+The following MicroProfile config properties could be used to override specific configuration attributes of these instances,
+
+[source, text]
+----
+org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.exec.maxAsync=5
+org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.exec.maxQueued=20
+org.eclipse.microprofile.example.ExampleBean.appContextPropagator.cleared=Security,Transaction
+----
+
 === Thread Context Provider SPI
 
 External providers of thread context can implement an SPI standardized by the MicroProfile Concurrency specification that allows capture/clear/propagate/restore operations to be plugged in for third party implementations of context.


### PR DESCRIPTION
pull fixes #31 

Write spec documentation for how MicroProfile Concurrency leverages MicroProfile Config to override configuration of instances produced by the container.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>