### PR TITLE
check in missed fixes for withContextCapture test

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -744,7 +744,7 @@ public class ThreadContextTest extends Arquillian {
                 Assert.assertEquals(Buffer.get().toString(), "withContextCapture-CompletionStage-test-buffer-A-stage3",
                         "Context type was not propagated to contextual action.");
 
-                Assert.assertEquals(Buffer.get().toString(), "",
+                Assert.assertEquals(Label.get(), "",
                         "Context type that is configured to be cleared was not cleared.");
 
                 Assert.assertEquals(Thread.currentThread().getId(), testThreadId,
@@ -772,7 +772,7 @@ public class ThreadContextTest extends Arquillian {
             // Has context been properly restored after the contextual operation(s)?
             Assert.assertEquals(Buffer.get().toString(), "withContextCapture-CompletionStage-test-buffer-E",
                     "Previous context was not restored after context was propagated for contextual action.");
-            Assert.assertEquals(Label.get(), "withContextCapture-CompletableFuture-test-label",
+            Assert.assertEquals(Label.get(), "withContextCapture-CompletionStage-test-label",
                     "Previous context was not restored after context was cleared for contextual action.");
         }
         finally {


### PR DESCRIPTION
When I wrote the TCK test for withContextCapture under #88, there were a couple of bugs in the test that I had to fix, but I forgot to add them to my commit.  This pull adds those fixes.  The TCK test will report erroneous failures without these fixes.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>