### PR TITLE
TCK tests for MPConfig overrides of ManagedExecutor injected into method parameter

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
@@ -36,7 +36,6 @@ import org.eclipse.microprofile.concurrent.ThreadContext;
 public class MPConfigBean {
     protected CompletableFuture<Integer> completedFuture;
 
-    // TODO need to write tests for this managed executor
     // microprofile-config.properties overrides this with maxAsync=2; maxQueued=3; propagated=Label; cleared=Remaining
     @Inject @ManagedExecutorConfig(
             maxAsync = 5,
@@ -52,14 +51,12 @@ public class MPConfigBean {
             cleared = ThreadContext.ALL_REMAINING)
     protected ManagedExecutor namedExecutorWithConfig;
 
-    // TODO need to write tests for this managed executor
     // microprofile-config.properties overrides this with maxAsync=1
     @Produces @ApplicationScoped @NamedInstance("producedExecutor")
     protected ManagedExecutor createExecutor(@ManagedExecutorConfig(maxQueued = 5) ManagedExecutor exec) {
         return exec;
     }
 
-    // TODO need to write tests for this managed executor
     // microprofile-config.properties overrides executor's config with maxAsync=1; maxQueued=2; propagated=Buffer,Label; cleared=Remaining
     @Inject
     protected void setCompletedFuture(ManagedExecutor executor) {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
@@ -281,7 +281,7 @@ public class MPConfigTest extends Arquillian {
             Future<String> future4 = producedExecutor.submit(() -> "Q_4");
             Future<String> future5 = producedExecutor.submit(() -> "Q_5");
 
-            // Fifth attempt to queue a task must be rejected
+            // Sixth attempt to queue a task must be rejected
             try {
                 Future<String> future6 = producedExecutor.submit(() -> "Q_6");
                 Assert.fail("Exceeded maxQueued of 5. Future for 6th queued task/action is " + future6);


### PR DESCRIPTION
Write TCK tests that cover the ability to use MicroProfile Config to override the configuration of ManagedExecutor instances that are created and injected by the container into injection points that are method parameters.  Also, added another test where the injection point is a field.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>