### PR TITLE
TCK tests for ThreadContext override via MicroProfile Config

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -55,6 +55,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
+import org.testng.ITestResult;
 import org.testng.annotations.Test;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -81,8 +82,12 @@ public class ManagedExecutorTest extends Arquillian {
     }
 
     @AfterMethod
-    public void afterMethod(Method m) {
-        System.out.println("<<< END ManagedExecutorTest." + m.getName());
+    public void afterMethod(Method m, ITestResult result) {
+        System.out.println("<<< END " + m.getClass().getSimpleName() + '.' + m.getName() + (result.isSuccess() ? " SUCCESS" : " FAILED"));
+        Throwable failure = result.getThrowable();
+        if (failure != null) {
+            failure.printStackTrace(System.out);
+        }
     }
 
     @BeforeClass
@@ -92,7 +97,7 @@ public class ManagedExecutorTest extends Arquillian {
 
     @BeforeMethod
     public void beforeMethod(Method m) {
-        System.out.println(">>> BEGIN ManagedExecutorTest." + m.getName());
+        System.out.println(">>> BEGIN " + m.getClass().getSimpleName() + '.' + m.getName());
     }
 
     @Deployment

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/TckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/TckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,15 +18,34 @@
  */
 package org.eclipse.microprofile.concurrency.tck;
 
+import java.lang.reflect.Method;
+
 import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
+import org.testng.ITestResult;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
 public class TckTest extends Arquillian {
+
+    @AfterMethod
+    public void afterMethod(Method m, ITestResult result) {
+        System.out.println("<<< END " + m.getClass().getSimpleName() + '.' + m.getName() + (result.isSuccess() ? " SUCCESS" : " FAILED"));
+        Throwable failure = result.getThrowable();
+        if (failure != null) {
+            failure.printStackTrace(System.out);
+        }
+    }
+
+    @BeforeMethod
+    public void beforeMethod(Method m) {
+        System.out.println(">>> BEGIN " + m.getClass().getSimpleName() + '.' + m.getName());
+    }
 
     @Deployment
     public static WebArchive createDeployment() {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -48,6 +48,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
+import org.testng.ITestResult;
 import org.testng.annotations.Test;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -74,8 +75,12 @@ public class ThreadContextTest extends Arquillian {
     }
 
     @AfterMethod
-    public void afterMethod(Method m) {
-        System.out.println("<<< END ThreadContextTest." + m.getName());
+    public void afterMethod(Method m, ITestResult result) {
+        System.out.println("<<< END " + m.getClass().getSimpleName() + '.' + m.getName() + (result.isSuccess() ? " SUCCESS" : " FAILED"));
+        Throwable failure = result.getThrowable();
+        if (failure != null) {
+            failure.printStackTrace(System.out);
+        }
     }
 
     @BeforeClass
@@ -85,7 +90,7 @@ public class ThreadContextTest extends Arquillian {
 
     @BeforeMethod
     public void beforeMethod(Method m) {
-        System.out.println(">>> BEGIN ThreadContextTest." + m.getName());
+        System.out.println(">>> BEGIN " + m.getClass().getSimpleName() + '.' + m.getName());
     }
 
     @Deployment

--- a/tck/src/main/resources/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/META-INF/microprofile-config.properties
@@ -29,7 +29,17 @@ org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedExecutorWithConfig.ma
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedExecutorWithConfig.cleared=ThreadPriority,Buffer,Transaction
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedExecutorWithConfig.propagated=Remaining
 
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedThreadContextWithConfig.propagated=Label,Buffer
+
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.maxAsync=1
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.maxQueued=2
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.propagated=Buffer,Label
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.cleared=Remaining
+
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.propagated=Label
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.unchanged=ThreadPriority
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.cleared=Remaining
+
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.propagated=
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.cleared=Buffer,ThreadPriority
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.unchanged=Remaining


### PR DESCRIPTION
Write TCK tests covering the override of configuration for ThreadContext instances that are created by the container for injection into field/method injection points for ThreadContext.  This includes those which are not annotated at all, those which are annotated with ThreadContextConfig, and those which are qualified with NamedInstance and annotated with ThreadContextConfig.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>