### PR TITLE
TCK test where MP Config overrides injection point with parameter position > 1

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executor;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.concurrency.tck.contexts.label.Label;
@@ -66,10 +67,19 @@ public class MPConfigBean {
     @Inject
     protected ThreadContext threadContext;
 
-    // microprofile-config.properties overrides this with maxAsync=1
+    // microprofile-config.properties overrides exec parameter with maxAsync=1
     @Produces @ApplicationScoped @NamedInstance("producedExecutor")
     protected ManagedExecutor createExecutor(@ManagedExecutorConfig(maxQueued = 5) ManagedExecutor exec) {
         return exec;
+    }
+
+    // microprofile-config.properties overrides threadContext parameter with propagated=Label
+    @Produces @ApplicationScoped @Named("producedThreadContext") // it's valid for user-supplied producers to use other qualifiers, such as Named
+    protected ThreadContext createThreadContext(
+            @NamedInstance("producedExecutor") ManagedExecutor unused1, // this is here so that we can force parameter position 3 to be used
+            @NamedInstance("namedExecutor") ManagedExecutor unused2, // this is here so that we can force parameter position 3 to be used
+            @ThreadContextConfig(propagated=Buffer.CONTEXT_NAME, cleared=ThreadContext.ALL_REMAINING) ThreadContext threadContext) {
+        return threadContext;
     }
 
     // microprofile-config.properties overrides executor's config with maxAsync=1; maxQueued=2; propagated=Buffer,Label; cleared=Remaining

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
@@ -423,7 +423,7 @@ public class MPConfigTest extends Arquillian {
 
         // Expected config is propagated=Label; unchanged=ThreadPriority, cleared=Remaining
         Assert.assertNotNull(producedThreadContext,
-                "Unable to inject ThreadContext into method parameter 3. Cannot run test.");
+                "Unable to inject ThreadContext. Cannot run test.");
 
         int originalPriority = Thread.currentThread().getPriority();
         try {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
@@ -29,8 +29,10 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.eclipse.microprofile.concurrency.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.concurrency.tck.contexts.buffer.spi.BufferContextProvider;
@@ -72,6 +74,9 @@ public class MPConfigTest extends Arquillian {
 
     @Inject @NamedInstance("producedExecutor")
     protected ManagedExecutor producedExecutor;
+
+    @Inject @Named("producedThreadContext") // other qualifiers such as @Named remain valid for app-defined producers
+    protected ThreadContext producedThreadContext;
 
     @AfterMethod
     public void afterMethod(Method m, ITestResult result) {
@@ -364,15 +369,16 @@ public class MPConfigTest extends Arquillian {
     /**
      * Verify that MicroProfile config overrides the cleared, propagated, and unchanged attributes
      * of a ThreadContext that is produced by the container when the application defines
-     * an unqualified parameter injection point that is annotated with ThreadContextConfig.
+     * an unqualified parameter injection point that is annotated with ThreadContextConfig,
+     * where the ThreadContext parameter is the first parameter of the method.
      */
     @Test(dependsOnMethods = "beanInjected")
-    public void overrideContextPropagationForThreadContextParameterWithConfig() {
+    public void overrideContextPropagationForThreadContextParameter1WithConfig() {
 
         // Expected config is propagated=Label; unchanged=ThreadPriority, cleared=Remaining
         Executor contextSnapshot = bean.getContextSnapshot();
         Assert.assertNotNull(contextSnapshot,
-                "Unable to inject ThreadContext into method parameter. Cannot run test.");
+                "Unable to inject ThreadContext into method parameter 1. Cannot run test.");
 
         int originalPriority = Thread.currentThread().getPriority();
         try {
@@ -403,6 +409,40 @@ public class MPConfigTest extends Arquillian {
             Buffer.set(null);
             Label.set(null);
             Thread.currentThread().setPriority(originalPriority);
+        }
+    }
+
+    /**
+     * Verify that MicroProfile config overrides the cleared, propagated, and unchanged attributes
+     * of a ThreadContext that is produced by the container when the application defines
+     * an unqualified parameter injection point that is annotated with ThreadContextConfig,
+     * where the ThreadContext parameter is the third parameter of the method.
+     */
+    @Test(dependsOnMethods = "beanInjected")
+    public void overrideContextPropagationForThreadContextParameter3WithConfig() {
+
+        // Expected config is propagated=Label; unchanged=ThreadPriority, cleared=Remaining
+        Assert.assertNotNull(producedThreadContext,
+                "Unable to inject ThreadContext into method parameter 3. Cannot run test.");
+
+        int originalPriority = Thread.currentThread().getPriority();
+        try {
+            // Set non-default values
+            Buffer.set(new StringBuffer("overrideThreadContextConfig3-test-buffer"));
+            Label.set("overrideThreadContextConfig3-test-label-A");
+
+            Supplier<String> appendLabelToBuffer = producedThreadContext.contextualSupplier(() ->
+                Buffer.get().append(Label.get()).toString());
+
+            Label.set("overrideThreadContextConfig3-test-label-B");
+
+            Assert.assertEquals(appendLabelToBuffer.get(), "overrideThreadContextConfig3-test-label-A",
+                    "Context type(s) not correctly propagated and/or cleared per MicroProfile Config overrides.");
+        }
+        finally {
+            // Restore original values
+            Buffer.set(null);
+            Label.set(null);
         }
     }
 

--- a/tck/src/main/resources/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/META-INF/microprofile-config.properties
@@ -20,6 +20,8 @@
 
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.createExecutor.1.maxAsync=1
 
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.createThreadContext.3.propagated=Label
+
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.maxAsync=2
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.maxQueued=3
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.propagated=Label


### PR DESCRIPTION
This pull adds at least one TCK test that covers MicroProfile Config override of configuration for a parameter injection point other than the first parameter.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>