### PR TITLE
Add TCK testing of ThreadContext for implied clearing of contexts.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
@@ -61,6 +61,12 @@ public class MPConfigBean {
             cleared = {},
             unchanged = ThreadContext.ALL_REMAINING)
     protected ThreadContext namedThreadContextWithConfig;
+    
+    // microprofile-config.properties overrides this with propagated=Buffer
+    @Inject @NamedInstance("clearAllRemainingThreadContext") @ThreadContextConfig(
+            propagated = ThreadContext.ALL_REMAINING,
+            unchanged = Label.CONTEXT_NAME)
+    protected ThreadContext clearAllRemainingThreadContext;
 
     // microprofile-config.properties overrides this with propagated=<unconfigured>; cleared=Buffer,ThreadPriority; unchanged=Remaining
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
@@ -449,7 +449,7 @@ public class MPConfigTest extends Arquillian {
                     "Context type that remained unspecified was not cleared by default.");
             
             Assert.assertEquals(Buffer.get().toString(), "clearUnspecifiedContexts-test-buffer-C",
-                    "Context type was not left unchanged by contextual action.");
+                    "Previous context (Buffer) was not restored after context was propagated for contextual action.");
             
             Assert.assertEquals(Label.get(), "clearUnspecifiedContexts-test-label-B",
                     "Context type was not left unchanged by contextual action.");

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -157,7 +157,7 @@ public class ThreadContextTest extends Arquillian {
                     "Context type that remained unspecified was not cleared by default.");
             
             Assert.assertEquals(Buffer.get().toString(), "clearUnspecifiedContexts-test-buffer-C",
-                    "Context type was not left unchanged by contextual action.");
+                    "Previous context (Buffer) was not restored after context was propagated for contextual action.");
             
             Assert.assertEquals(Label.get(), "clearUnspecifiedContexts-test-label-B",
                     "Context type was not left unchanged by contextual action.");

--- a/tck/src/main/resources/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/META-INF/microprofile-config.properties
@@ -43,3 +43,5 @@ org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.clear
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.propagated=
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.cleared=Buffer,ThreadPriority
 org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.unchanged=Remaining
+
+org.eclipse.microprofile.concurrency.tck.MPConfigBean.clearAllRemainingThreadContext.propagated=Buffer


### PR DESCRIPTION
Write TCK tests covering the ThreadContext.Builder.cleared() API will implicitly include all remaining contexts there were not otherwise specified. Including testing with MicroProfile Config to create a scenario where the cleared list should be updated through an indirect change of the propagated list.

Signed-off-by: Nathan Mittlestat <nmittles@us.ibm.com>