### PR TITLE
Fix some specification text errors

### DIFF
--- a/spec/src/main/asciidoc/concurrencyprovider.asciidoc
+++ b/spec/src/main/asciidoc/concurrencyprovider.asciidoc
@@ -33,7 +33,7 @@ In the case where the `ConcurrencyProvider` implementation is distinct from the 
 
 === Concurrency Manager
 
-`ConcurrencyManager`'s purpose is to provide builders for `ManagedExecutor` and `ThreadContext`. The builders create instances of `ManagedExecutor` and `ThreadContext` where thread context management is based on the `ThreadContextProvider`s that are accessible to the `ServiceLoader` from the class loader that is associated with the `ConcurrencyManager` instance.
+``ConcurrencyManager``'s purpose is to provide builders for `ManagedExecutor` and `ThreadContext`. The builders create instances of `ManagedExecutor` and `ThreadContext` where thread context management is based on the `ThreadContextProvider`s that are accessible to the `ServiceLoader` from the class loader that is associated with the `ConcurrencyManager` instance.
 
 === Concurrency Manager Builder
 

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -38,8 +38,7 @@ MicroProfile Config can be used to override configuration attributes from the ab
 [source, text]
 ----
 exec1.maxAsync=10
-exec1.propagated=Application,CDI
-exec1.cleared=Remaining
+exec1.maxQueued=15
 ----
 
 === Container usage of MicroProfile Config

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -84,7 +84,7 @@ Container provides, per unique name, an instance of either `ManagedExecutor` and
 ----
 
 In the absence of other qualifiers and annotations, the container creates and injects a new default instance of `ManagedExecutor` or `ThreadContext` per injection point, as shown above.
-The configuration of these instances is equivalent to the default values of `@ManagedExecutorConfig` and `ThreadContextConfig`.
+The configuration of these instances is equivalent to the default values of `@ManagedExecutorConfig` and `@ThreadContextConfig`.
 
 === Injection of Configured Instances
 


### PR DESCRIPTION
- code escape overrun in concurrencyprovider.asciidoc
- missing `@` for ThreadContextConfig in overview.asciidoc
- adjusted application MP config example to use only properties visible in the example in mpconfig.asciidoc