### PR TITLE
Add TCK testing of ManagedExecutor for implied clearing of contexts.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -158,6 +158,7 @@ public class ManagedExecutorTest extends Arquillian {
                     "Previous context (Buffer) was not restored after context was propagated for contextual action.");
         }
         finally {
+            executor.shutdownNow();
             // Restore original values
             Buffer.set(null);
             Thread.currentThread().setPriority(originalPriority);


### PR DESCRIPTION
Write TCK tests covering the ManagedExecutor.Builder.cleared() API will implicitly include all remaining contexts there were not otherwise specified.

Signed-off-by: Nathan Mittlestat <nmittles@us.ibm.com>