### PR TITLE
Add section on MP Config overrides for array value properties, clarifying how to configure empty values

### DIFF
--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -119,7 +119,7 @@ package org.eclipse.microprofile.example;
 ...
 public class MyBean {
     @Inject
-    ThreadContext appAndCDIContextPropagator;
+    ThreadContext contextPropagator;
 }
 ----
 
@@ -127,9 +127,14 @@ If the user wishes to override the above to propagate exactly 2 context types (`
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean.appAndCDIContextPropagator.propagated=Application,CDI
-org.eclipse.microprofile.example.MyBean.appAndCDIContextPropagator.cleared=
-org.eclipse.microprofile.example.MyBean.appAndCDIContextPropagator.unchanged=Remaining
+org.eclipse.microprofile.example.MyBean.contextPropagator.propagated=Application,CDI
+org.eclipse.microprofile.example.MyBean.contextPropagator.cleared=
+org.eclipse.microprofile.example.MyBean.contextPropagator.unchanged=Remaining
 ----
 
-In order to guarantee that empty string config values are interpreted properly, the MicroProfile Concurrency implementation must accept both an empty array or collection as well as a size 1 array or collection containing the empty string as meaning empty.  This is necessary due to a lack of clarity in the first several versions of the MicroProfile Config specification about how the empty string value is to be interpreted for arrays and collections of String.
+In order to guarantee that empty string config values are interpreted properly, the MicroProfile Concurrency implementation must interpret both of the following as indicating empty:
+
+* empty array
+* array containing the empty String as its singular element
+
+This is necessary due to a lack of clarity in the first several versions of the MicroProfile Config specification about how the empty string value is to be interpreted for arrays of String.

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -101,3 +101,35 @@ org.eclipse.microprofile.example.MyBean.createExecutor.1.maxAsync=10
 ----
 
 Again, it would be wrong to specify `org.eclipse.microprofile.example.MyBean.exec6.maxAsync`, because the container does not produce a new instance for the `exec6` injection point. The container produces the new instance for the `exec` injection point, and matches that same instance for injection into `exec6` per the `@NamedInstance("executor6")` qualifier.
+
+=== Overriding Array Properties in MicroProfile Config
+
+MicroProfile Config can be used to override array type properties (`propagated`, `cleared`, and `unchanged`) on injection points for which the container creates `ManagedExecutor` or `ThreadContext` instances. The following rules apply for config property values:
+
+- The value can be a single array element, multiple elements (delimited by `,`), or empty.
+- Array elements can be any value returned by a ``ThreadContextProvider``'s `getThreadContextType()` method.
+- Array elements can be any thread context type constant value from ThreadContext (such as `Security`, `Application`, or `Remaining`).
+- The usual rules from the MicroProfile Config specification apply, such as escaping special characters.
+
+For example, we can start with the following injection point, which has the default configuration for `ThreadContext`. This means clearing the `Transaction` context, leaving no context type unchanged, and propagating all `Remaining` context types,
+
+[source, java]
+----
+package org.eclipse.microprofile.example;
+...
+public class MyBean {
+    @Inject
+    ThreadContext appAndCDIContextPropagator;
+}
+----
+
+If the user wishes to override the above to propagate exactly 2 context types (`Application` and `CDI`), clear nothing, and leave all `Remaining` types unchanged, then they could configure the following MicroProfile Config properties,
+
+[source, text]
+----
+org.eclipse.microprofile.example.MyBean.appAndCDIContextPropagator.propagated=Application,CDI
+org.eclipse.microprofile.example.MyBean.appAndCDIContextPropagator.cleared=
+org.eclipse.microprofile.example.MyBean.appAndCDIContextPropagator.unchanged=Remaining
+----
+
+In order to guarantee that empty string config values are interpreted properly, the MicroProfile Concurrency implementation must accept both an empty array or collection as well as a size 1 array or collection containing the empty string as meaning empty.  This is necessary due to a lack of clarity in the first several versions of the MicroProfile Config specification about how the empty string value is to be interpreted for arrays and collections of String.


### PR DESCRIPTION
pull fixes #99 

This pull provides an example of using MicroProfile Config to override array properties (the lists of context types) and documents a requirement that MicroProfile Concurrency providers will need to be aware of to cope with an ambiguity in MicroProfile Config around empty values in a consistent manner.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>