### PR TITLE
withContextCapture must reject Async methods without executor because it is not backed by an executor

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -420,10 +420,11 @@ public interface ThreadContext {
      * <p>Returns a new <code>CompletableFuture</code> that is completed by the completion of the
      * specified stage.</p>
      *
-     * <p>The new completable future is backed by a ThreadContext rather than a ManagedExecutor,
-     * and therefore its default asynchronous execution facility, which is supplied by the container,
-     * must run all dependent stages (and all dependent stages created from those, and so forth)
-     * inline rather than as separate asynchronous requests.</p>
+     * <p>The new completable future is backed by a ThreadContext rather than a ManagedExecutor.
+     * Therefore, the new stage and all dependent stages created from it, and so forth,
+     * have no default asynchronous execution facility and must raise {@link java.lang.UnsupportedOperationException}
+     * for all <code>*Async</code> methods that do not specify an executor. For example,
+     * {@link java.util.concurrent.CompletionStage#thenRunAsync(Runnable) thenRunAsync(Runnable)}.</p>
      *
      * <p>When dependent stages are created from the new completable future, thread context is captured
      * from the thread that creates the dependent stage and is applied to the thread that runs the
@@ -447,10 +448,11 @@ public interface ThreadContext {
      * <p>Returns a new <code>CompletionStage</code> that is completed by the completion of the
      * specified stage.</p>
      *
-     * <p>The new completion stage is backed by a ThreadContext rather than a ManagedExecutor,
-     * and therefore its default asynchronous execution facility, which is supplied by the container,
-     * must run all dependent stages (and all dependent stages created from those, and so forth)
-     * inline rather than as separate asynchronous requests.</p>
+     * <p>The new completion stage is backed by a ThreadContext rather than a ManagedExecutor.
+     * Therefore, the new stage and all dependent stages created from it, and so forth,
+     * have no default asynchronous execution facility and must raise {@link java.lang.UnsupportedOperationException}
+     * for all <code>*Async</code> methods that do not specify an executor. For example,
+     * {@link java.util.concurrent.CompletionStage#thenRunAsync(Runnable) thenRunAsync(Runnable)}.</p>
      *
      * <p>When dependent stages are created from the new completion stage, thread context is captured
      * from the thread that creates the dependent stage and is applied to the thread that runs the


### PR DESCRIPTION
pull fixes #107

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>