### PR TITLE
TCK tests for cdi injection of ThreadContext

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/BasicCDITest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/BasicCDITest.java
@@ -18,14 +18,24 @@
  */
 package org.eclipse.microprofile.concurrency.tck.cdi;
 
+import java.lang.reflect.Method;
+
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.concurrency.tck.contexts.buffer.spi.BufferContextProvider;
+import org.eclipse.microprofile.concurrency.tck.contexts.label.spi.LabelContextProvider;
+import org.eclipse.microprofile.concurrency.tck.contexts.priority.spi.ThreadPriorityContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.ITestResult;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
 public class BasicCDITest extends Arquillian {
 
@@ -34,11 +44,35 @@ public class BasicCDITest extends Arquillian {
     @Inject
     CDIBean bean;
 
+    @AfterMethod
+    public void afterMethod(Method m, ITestResult result) {
+        System.out.println("<<< END " + m.getClass().getSimpleName() + '.' + m.getName() + (result.isSuccess() ? " SUCCESS" : " FAILED"));
+        Throwable failure = result.getThrowable();
+        if (failure != null) {
+            failure.printStackTrace(System.out);
+        }
+    }
+
+    @BeforeMethod
+    public void beforeMethod(Method m) {
+        System.out.println(">>> BEGIN " + m.getClass().getSimpleName() + '.' + m.getName());
+    }
+
     @Deployment
     public static WebArchive createDeployment() {
+        // build a JAR that provides three fake context types: 'Buffer', 'Label', and 'ThreadPriority'
+        JavaArchive fakeContextProviders = ShrinkWrap.create(JavaArchive.class, "fakeContextTypes.jar")
+                .addPackages(true, "org.eclipse.microprofile.concurrency.tck.contexts.buffer")
+                .addPackages(true, "org.eclipse.microprofile.concurrency.tck.contexts.label")
+                .addPackage("org.eclipse.microprofile.concurrency.tck.contexts.priority.spi")
+                .addAsServiceProvider(ThreadContextProvider.class,
+                        BufferContextProvider.class, LabelContextProvider.class, ThreadPriorityContextProvider.class);
+
         return ShrinkWrap.create(WebArchive.class, BasicCDITest.class.getSimpleName() + ".war")
-                .addPackage("org.eclipse.microprofile.concurrency.tck.cdi")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addClass(CDIBean.class)
+                .addClass(BasicCDITest.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsLibraries(fakeContextProviders);
     }
     
     @Test
@@ -66,4 +100,18 @@ public class BasicCDITest extends Arquillian {
         bean.shutdownContainerInstance();
     }
 
+    @Test
+    public void instancePerUnqualifiedThreadContextInjectionPoint() {
+        bean.testInstancePerUnqualifiedThreadContextInjectionPoint();
+    }
+
+    @Test
+    public void threadContextConfigProvidesConfiguration() {
+        bean.testThreadContextConfig();
+    }
+
+    @Test
+    public void threadContextConfigNamedInstanceAutomaticallyProducesInstance() {
+        bean.testThreadContextConfigNamedInstance();
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/BasicCDITest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/BasicCDITest.java
@@ -114,4 +114,24 @@ public class BasicCDITest extends Arquillian {
     public void threadContextConfigNamedInstanceAutomaticallyProducesInstance() {
         bean.testThreadContextConfigNamedInstance();
     }
+
+    @Test
+    public void applicationDefinesProducerOfThreadContext() {
+        bean.testAppDefinedProducerOfThreadContext();
+    }
+
+    @Test
+    public void applicationDefinesProducerUsingInjectedThreadContext() {
+        bean.testAppDefinedProducerUsingInjectedThreadContext();
+    }
+
+    @Test
+    public void injectThreadContextWithoutConfig() {
+        bean.testInjectThreadContextNoConfig();
+    }
+
+    @Test
+    public void injectThreadContextWithEmptyConfig() throws Exception {
+        bean.testInjectThreadContextEmptyConfig();
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIBean.java
@@ -400,6 +400,9 @@ public class CDIBean {
      * Application-defined producer methods can have injection points of ThreadContext that are provided by the container.
      */
     public void testAppDefinedProducerUsingInjectedThreadContext() {
+        Assert.assertNotNull(priority3Executor,
+                "Application should be able to create its own CDI producer that injects a ThreadContext that is provided by the container.");
+
         int originalPriority = Thread.currentThread().getPriority();
         int newPriority = originalPriority == 2 ? 1 : 2;
         try {
@@ -432,6 +435,9 @@ public class CDIBean {
      * types are propagated, except for Transaction context, which is cleared.
      */
     public void testInjectThreadContextNoConfig() {
+        Assert.assertNotNull(defaultContext,
+                "Container must produce ThreadContext instance for unqualified injection point that lacks ThreadContextConfig.");
+
         int originalPriority = Thread.currentThread().getPriority();
         int newPriority = originalPriority == 2 ? 1 : 2;
         try {
@@ -469,6 +475,9 @@ public class CDIBean {
      * types are propagated, except for Transaction context, which is cleared.
      */
     public void testInjectThreadContextEmptyConfig() throws Exception {
+        Assert.assertNotNull(defaultContextWithEmptyAnno,
+                "Container must produce ThreadContext instance for injection point that is annotated with ThreadContextConfig.");
+
         int originalPriority = Thread.currentThread().getPriority();
         int newPriority = originalPriority == 2 ? 1 : 2;
         try {
@@ -476,19 +485,19 @@ public class CDIBean {
             Label.set("testInjectThreadContextEmptyConfig-label");
             Buffer.set(new StringBuffer("testInjectThreadContextEmptyConfig-buffer"));
 
-            Callable<Boolean> testAllContextPropagated = defaultContext.contextualCallable(() -> {
+            Callable<Boolean> testAllContextPropagated = defaultContextWithEmptyAnno.contextualCallable(() -> {
                 Assert.assertEquals(Buffer.get().toString(), "testInjectThreadContextEmptyConfig-buffer",
                         "Thread context type (Buffer) was not propagated.");
                 Assert.assertEquals(Label.get(), "testInjectThreadContextEmptyConfig-label",
-                        "Thread context type (Lable) was not propagated.");
+                        "Thread context type (Label) was not propagated.");
                 Assert.assertEquals(Thread.currentThread().getPriority(), newPriority,
                         "Thread context type (ThreadPriority) was not propagated.");
                 return true;
             });
 
             Thread.currentThread().setPriority(4);
-            Label.set("testInjectThreadContextNoConfig-new-label");
-            Buffer.set(new StringBuffer("testInjectThreadContextNoConfig-new-buffer"));
+            Label.set("testInjectThreadContextEmptyConfig-new-label");
+            Buffer.set(new StringBuffer("testInjectThreadContextEmptyConfig-new-buffer"));
 
             testAllContextPropagated.call();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/ManagedExecutorSharingTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/ManagedExecutorSharingTest.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.microprofile.concurrency.tck.cdi;
 
+import java.lang.reflect.Method;
+
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -26,7 +28,10 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
+import org.testng.ITestResult;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
 /**
  * Tests sharing rules of ManagedExecutors injected via CDI
@@ -38,10 +43,25 @@ public class ManagedExecutorSharingTest extends Arquillian {
     @Inject
     ManagedExecutorSharingBean bean;
 
+    @AfterMethod
+    public void afterMethod(Method m, ITestResult result) {
+        System.out.println("<<< END " + m.getClass().getSimpleName() + '.' + m.getName() + (result.isSuccess() ? " SUCCESS" : " FAILED"));
+        Throwable failure = result.getThrowable();
+        if (failure != null) {
+            failure.printStackTrace(System.out);
+        }
+    }
+
+    @BeforeMethod
+    public void beforeMethod(Method m) {
+        System.out.println(">>> BEGIN " + m.getClass().getSimpleName() + '.' + m.getName());
+    }
+
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, ManagedExecutorSharingTest.class.getSimpleName() + ".war")
-                .addPackage("org.eclipse.microprofile.concurrency.tck.cdi")
+                .addClass(ManagedExecutorSharingBean.class)
+                .addClass(ManagedExecutorSharingTest.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
     


### PR DESCRIPTION
Write TCK tests to cover the following scenarios:
- The container creates a ThreadContext instance per unqualified ThreadContext injection point
- A ThreadContext instance that is injected by the container can be configured via `@ThreadContextConfig`
- If the `@NamedInstance` qualifier is present on a ThreadContext injection point that is annotated with `@ThreadContextConfig`, the container creates a ThreadContext instance that is qualified by the name value 