### PR TITLE
update TCK tests to expect that supplied executor parameter does not override context propagation

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
@@ -146,12 +146,12 @@ public class MPConfigTest extends Arquillian {
             // Set non-default values
             int newPriority = originalPriority == 3 ? 2 : 3;
             Thread.currentThread().setPriority(newPriority);
-            Buffer.set(new StringBuffer("overrideMangedExecutorConfig-test-buffer"));
-            Label.set("overrideMangedExecutorConfig-test-label");
+            Buffer.set(new StringBuffer("overrideManagedExecutorConfig-test-buffer"));
+            Label.set("overrideManagedExecutorConfig-test-label");
 
             // Run on separate thread to test propagated
             CompletableFuture<Void> stage1 = namedExecutor.runAsync(() ->
-                Assert.assertEquals(Label.get(), "overrideMangedExecutorConfig-test-label",
+                Assert.assertEquals(Label.get(), "overrideManagedExecutorConfig-test-label",
                         "Context type that MicroProfile config overrides to be propagated was not correctly propagated.")
             );
 
@@ -247,8 +247,8 @@ public class MPConfigTest extends Arquillian {
             // Set non-default values
             int newPriority = originalPriority == 2 ? 1 : 2;
             Thread.currentThread().setPriority(newPriority);
-            Buffer.set(new StringBuffer("overrideMangedExecutorConfig-test-buffer"));
-            Label.set("overrideMangedExecutorConfig-test-label");
+            Buffer.set(new StringBuffer("overrideManagedExecutorConfig-test-buffer"));
+            Label.set("overrideManagedExecutorConfig-test-label");
 
             // Run on current thread to test cleared
             CompletableFuture<Void> stage1 = completedFuture.thenRun(() ->
@@ -261,10 +261,10 @@ public class MPConfigTest extends Arquillian {
 
             // Run on separate thread to test propagated
             CompletableFuture<Void> stage2 = completedFuture.thenRunAsync(() -> {
-                Assert.assertEquals(Label.get(), "overrideMangedExecutorConfig-test-label",
+                Assert.assertEquals(Label.get(), "overrideManagedExecutorConfig-test-label",
                         "Context type (Label) that MicroProfile config overrides to be propagated was not correctly propagated.");
 
-                Assert.assertEquals(Buffer.get().toString(), "overrideMangedExecutorConfig-test-buffer",
+                Assert.assertEquals(Buffer.get().toString(), "overrideManagedExecutorConfig-test-buffer",
                         "Context type (Buffer) that MicroProfile config overrides to be propagated was not correctly propagated.");
             });
 

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -139,7 +139,7 @@ public class ManagedExecutorTest extends Arquillian {
                 .propagated(Buffer.CONTEXT_NAME)
                 .build();
         
-        int originalPriority = Thread.currentThread().getPriority();     
+        int originalPriority = Thread.currentThread().getPriority();
         try {
             // Set non-default values
             int newPriority = originalPriority == 3 ? 2 : 3;
@@ -359,7 +359,7 @@ public class ManagedExecutorTest extends Arquillian {
     
     /**
      * Verify the MicroProfile Concurrency implementation of propagate(), and cleared()
-     * for MangedExecutor.Builder.
+     * for ManagedExecutor.Builder.
      */
     @Test
     public void contextControlsForManagedExecutorBuilder() throws InterruptedException, ExecutionException, TimeoutException {
@@ -1819,7 +1819,7 @@ public class ManagedExecutorTest extends Arquillian {
                         "Context type that is configured to be cleared was not cleared.");
 
                 Assert.assertEquals(Label.get(), "runAsync-test-label-A",
-                        "Context type was not correctly propagated to contextual action.");                
+                        "Context type was not correctly propagated to contextual action.");
             });
 
             Label.set("runAsync-test-label-B");
@@ -1829,18 +1829,18 @@ public class ManagedExecutorTest extends Arquillian {
                         "Context type that is configured to be cleared was not cleared.");
 
                 Assert.assertEquals(Label.get(), "runAsync-test-label-B",
-                        "Context type was not correctly propagated to contextual action.");                
+                        "Context type was not correctly propagated to contextual action.");
             });
 
             Label.set("runAsync-test-label-C");
 
             CompletableFuture<Void> stage3 = stage2.thenRunAsync(() -> {
                 Assert.assertEquals(Buffer.get().toString(), "",
-                        "Context type (Buffer) should not be propagated when specifying a non-managed executor.");
+                        "Context type that is configured to be cleared was not cleared.");
 
-                Assert.assertEquals(Label.get(), "",
-                        "Context type (Label) should not be propagated when specifying a non-managed executor.");                
-            }, unmanagedThreads);
+                Assert.assertEquals(Label.get(), "runAsync-test-label-C",
+                        "Context type was not correctly propagated to contextual action.");
+            }, unmanagedThreads); // supplied executor runs the action, but does not determine context propagation
 
             Label.set("runAsync-test-label-D");
 

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -801,8 +801,8 @@ public class ThreadContextTest extends Arquillian {
                 .propagated(Label.CONTEXT_NAME)
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
-        ManagedExecutor labelContextExecutor = ManagedExecutor.builder()
-                .propagated(Label.CONTEXT_NAME)
+        ManagedExecutor bufferContextExecutor = ManagedExecutor.builder()
+                .propagated(Buffer.CONTEXT_NAME)
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -849,7 +849,7 @@ public class ThreadContextTest extends Arquillian {
                 Label.set("withContextCapture-CompletableFuture-test-label-D");
 
                 return i + i;
-            }, labelContextExecutor);
+            }, bufferContextExecutor); // supplied executor runs the action, but does not determine context propagation
 
             // Original stage remains usable, but not having been created by a ManagedExecutor, does not make any
             // guarantees about context propagation
@@ -886,7 +886,7 @@ public class ThreadContextTest extends Arquillian {
                     "Previous context was not restored after context was propagated for contextual action.");
         }
         finally {
-            labelContextExecutor.shutdownNow();
+            bufferContextExecutor.shutdownNow();
             // Restore original values
             Buffer.set(null);
             Label.set(null);
@@ -905,8 +905,8 @@ public class ThreadContextTest extends Arquillian {
                 .propagated(Buffer.CONTEXT_NAME)
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
-        ManagedExecutor bufferContextExecutor = ManagedExecutor.builder()
-                .propagated(Buffer.CONTEXT_NAME)
+        ManagedExecutor labelContextExecutor = ManagedExecutor.builder()
+                .propagated(Label.CONTEXT_NAME)
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -967,7 +967,7 @@ public class ThreadContextTest extends Arquillian {
                 Buffer.set(new StringBuffer("withContextCapture-CompletionStage-test-buffer-D"));
 
                 return i - 2345;
-            }, bufferContextExecutor);
+            }, labelContextExecutor); // supplied executor runs the action, but does not determine context propagation
 
             try {
                 CompletionStage<Void> stage5 = stage4.thenAcceptAsync(i -> System.out.println("This should not ever run."));
@@ -995,7 +995,7 @@ public class ThreadContextTest extends Arquillian {
                     "Previous context was not restored after context was cleared for contextual action.");
         }
         finally {
-            bufferContextExecutor.shutdownNow();
+            labelContextExecutor.shutdownNow();
             // Restore original values
             Buffer.set(null);
             Label.set(null);


### PR DESCRIPTION
This pull contains updates to the TCK per the expected resolution of issue #110 
which is that an executor parameter which is supplied as an argument to a completionStage.*Async method does not determine the thread context propagation.  Instead, the managed executor which is the default asynchronous execution facility for the stage is what determines the thread context propagation.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>