### PR TITLE
align MPConfig overrides of config annotations with the approach used by MP FaultTolerance

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -32,8 +32,9 @@ import javax.enterprise.util.AnnotationLiteral;
 /**
  * <p>Annotates a CDI injection point for a {@link ManagedExecutor} such that the container
  * creates a new instance, which is identified within an application by its unique name.
- * The unique name is generated as the fully qualified class and field name of the
- * injection point separated by <code>.</code>, unless annotated with the {@link NamedInstance} qualifier,
+ * The unique name is generated as the fully qualified class name (with each component delimited by <code>.</code>)
+ * and the injection point's field name or method name and parameter position, all delimited by <code>/</code>,
+ * unless annotated with the {@link NamedInstance} qualifier,
  * in which case the unique name is specified by the {@link NamedInstance#value value} attribute of that qualifier.</p>
  *
  * <p>For example, the following injection points share a single

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -32,8 +32,9 @@ import javax.enterprise.util.AnnotationLiteral;
 /**
  * <p>Annotates a CDI injection point for a {@link ThreadContext} such that the container
  * creates a new instance, which is identified within an application by its unique name.
- * The unique name is generated as the fully qualified class and field name of the
- * injection point separated by <code>.</code>, unless annotated with the {@link NamedInstance} qualifier,
+ * The unique name is generated as the fully qualified class name (with each component delimited by <code>.</code>)
+ * and the injection point's field name or method name and parameter position, all delimited by <code>/</code>,
+ * unless annotated with the {@link NamedInstance} qualifier,
  * in which case the unique name is specified by the {@link NamedInstance#value value} attribute of that qualifier.</p>
  *
  * <p>For example, the following injection points share a single

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -47,7 +47,7 @@ The container produces an instance per unqualified `ManagedExecutor` injection p
 
 In each of these cases, MicroProfile Config can be used to override the configuration of the instance that is produced by the container.
 
-To override a configuration attribute of an instance that is produced for injection into a field, specify a MicroProfile Config property with the name equal to the fully qualified class name, field name, and configuration attribute name, delimited by the `.` character.
+To override a configuration attribute of an instance that is produced for injection into a field, specify a MicroProfile Config property with the name equal to the fully qualified class name, field name, annotation name, and annotation attribute name, delimited by the `/` character.
 
 [source, java]
 ----
@@ -70,14 +70,16 @@ public class MyBean {
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean.exec2.maxAsync=5
-org.eclipse.microprofile.example.MyBean.exec3.maxAsync=6
-org.eclipse.microprofile.example.MyBean.exec4.maxAsync=7
+org.eclipse.microprofile.example.MyBean/exec2/ManagedExecutorConfig/maxAsync=5
+org.eclipse.microprofile.example.MyBean/exec3/ManagedExecutorConfig/maxAsync=6
+org.eclipse.microprofile.example.MyBean/exec4/ManagedExecutorConfig/maxAsync=7
 ----
 
-Note that `org.eclipse.microprofile.example.MyBean.exec4.maxAsync` overrides the configuration of the instance that is produced for injection into `exec4`. This same instance is injected into `exec5` per the matching `@NamedInstance("executor4")` qualifier.  It is an error to specify `org.eclipse.microprofile.example.MyBean.exec5.maxAsync`, which will not apply to `exec5`.
+Note that `exec2` can be overridden with `ManagedExecutorConfig` attributes even though it does not explicitly declare a `ManagedExecutorConfig` annotation.
 
-To override a configuration attribute of an instance that is produced for injection into a parameter, specify a MicroProfile Config property with its name equal to the fully qualified class name, method name, parameter number (starting at 1), and configuration attribute name, delimited by the `.` character.
+Note that `org.eclipse.microprofile.example.MyBean/exec4/ManagedExecutorConfig/maxAsync` overrides the configuration of the instance that is produced for injection into `exec4`. This same instance is injected into `exec5` per the matching `@NamedInstance("executor4")` qualifier.  It is incorrect to specify `org.eclipse.microprofile.example.MyBean/exec5/ManagedExecutorConfig/maxAsync`, which will not apply to `exec5`.
+
+To override a configuration attribute of an instance that is produced for injection into a parameter, specify a MicroProfile Config property with its name equal to the fully qualified class name, method name, parameter number (starting at 1), annotation name, and annotation attribute name, delimited by the `/` character.
 
 [source, java]
 ----
@@ -96,10 +98,10 @@ public class MyBean {
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean.createExecutor.1.maxAsync=10
+org.eclipse.microprofile.example.MyBean/createExecutor/1/ManagedExecutorConfig/maxAsync=10
 ----
 
-Again, it would be wrong to specify `org.eclipse.microprofile.example.MyBean.exec6.maxAsync`, because the container does not produce a new instance for the `exec6` injection point. The container produces the new instance for the `exec` injection point, and matches that same instance for injection into `exec6` per the `@NamedInstance("executor6")` qualifier.
+Again, it would be wrong to specify `org.eclipse.microprofile.example.MyBean/exec6/ManagedExecutorConfig/maxAsync`, because the container does not produce a new instance for the `exec6` injection point. The container produces the new instance for the `exec` injection point, and matches that same instance for injection into `exec6` per the `@NamedInstance("executor6")` qualifier.
 
 === Overriding Array Properties in MicroProfile Config
 
@@ -126,9 +128,9 @@ If the user wishes to override the above to propagate exactly 2 context types (`
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean.contextPropagator.propagated=Application,CDI
-org.eclipse.microprofile.example.MyBean.contextPropagator.cleared=
-org.eclipse.microprofile.example.MyBean.contextPropagator.unchanged=Remaining
+org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/propagated=Application,CDI
+org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/cleared=
+org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/unchanged=Remaining
 ----
 
 In order to guarantee that empty string config values are interpreted properly, the MicroProfile Concurrency implementation must interpret both of the following as indicating empty:

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,9 +130,9 @@ The other injection points, `executor2` and `executor3`, share the same `Managed
 
 === Integration with MicroProfile Config
 
-This specification defines a convention for defining properties in MicroProfile Config that override configuration attributes of `ManagedExecutor` and `ThreadContext` instances that are produced by the container. The convention for the property name is the fully qualified name of the injection point, with the `.` character as delimiter.
+This specification defines a convention for defining properties in MicroProfile Config that override configuration attributes of `ManagedExecutor` and `ThreadContext` instances that are produced by the container. The convention for the property name is the fully qualified class name of the injection point, combined with the injection point field name or method name with parameter position, annotation name, and annotation attribute, with the `/` character as delimiter.
 
-The following example shows one injection point for `ManagedExecutor`, which is the first parameter of the `setCompletableFuture` method, and another injection point for `ThreadContext`, which is the `appContextPropagator` field.
+The following example shows one injection point for `ManagedExecutor`, which is the first parameter of the `setCompletableFuture` method, and another injection point for `ThreadContext`, which is the `appContext` field.
 
 [source, java]
 ----
@@ -157,7 +157,7 @@ public class ExampleBean {
     @Inject @ThreadContextConfig(propagated = ThreadContext.APPLICATION,
                                  cleared = ThreadContext.TRANSACTION,
                                  unchanged = ThreadContext.ALL_REMAINING)
-    ThreadContext appContextPropagator;
+    ThreadContext appContext;
 }
 ----
 
@@ -165,9 +165,9 @@ The following MicroProfile config properties could be used to override specific 
 
 [source, text]
 ----
-org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.1.maxAsync=5
-org.eclipse.microprofile.example.ExampleBean.setCompletableFuture.1.maxQueued=20
-org.eclipse.microprofile.example.ExampleBean.appContextPropagator.cleared=Security,Transaction
+org.eclipse.microprofile.example.ExampleBean/setCompletableFuture/1/ManagedExecutorConfig/maxAsync=5
+org.eclipse.microprofile.example.ExampleBean/setCompletableFuture/1/ManagedExecutorConfig/maxQueued=20
+org.eclipse.microprofile.example.ExampleBean/appContext/ThreadContextConfig/cleared=Security,Transaction
 ----
 
 === Thread Context Provider SPI

--- a/tck/src/main/resources/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/META-INF/microprofile-config.properties
@@ -18,32 +18,32 @@
 # under the License.
 #
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.createExecutor.1.maxAsync=1
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/createExecutor/1/ManagedExecutorConfig/maxAsync=1
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.createThreadContext.3.propagated=Label
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/createThreadContext/3/ThreadContextConfig/propagated=Label
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.maxAsync=2
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.maxQueued=3
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.propagated=Label
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.executorWithConfig.cleared=Remaining
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/executorWithConfig/ManagedExecutorConfig/maxAsync=2
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/executorWithConfig/ManagedExecutorConfig/maxQueued=3
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/executorWithConfig/ManagedExecutorConfig/propagated=Label
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/executorWithConfig/ManagedExecutorConfig/cleared=Remaining
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedExecutorWithConfig.maxQueued=4
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedExecutorWithConfig.cleared=ThreadPriority,Buffer,Transaction
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedExecutorWithConfig.propagated=Remaining
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/namedExecutorWithConfig/ManagedExecutorConfig/maxQueued=4
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/namedExecutorWithConfig/ManagedExecutorConfig/cleared=ThreadPriority,Buffer,Transaction
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/namedExecutorWithConfig/ManagedExecutorConfig/propagated=Remaining
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.namedThreadContextWithConfig.propagated=Label,Buffer
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/namedThreadContextWithConfig/ThreadContextConfig/propagated=Label,Buffer
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.maxAsync=1
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.maxQueued=2
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.propagated=Buffer,Label
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setCompletedFuture.1.cleared=Remaining
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setCompletedFuture/1/ManagedExecutorConfig/maxAsync=1
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setCompletedFuture/1/ManagedExecutorConfig/maxQueued=2
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setCompletedFuture/1/ManagedExecutorConfig/propagated=Buffer,Label
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setCompletedFuture/1/ManagedExecutorConfig/cleared=Remaining
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.propagated=Label
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.unchanged=ThreadPriority
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.setContextSnapshot.1.cleared=Remaining
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setContextSnapshot/1/ThreadContextConfig/propagated=Label
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setContextSnapshot/1/ThreadContextConfig/unchanged=ThreadPriority
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/setContextSnapshot/1/ThreadContextConfig/cleared=Remaining
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.propagated=
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.cleared=Buffer,ThreadPriority
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.threadContext.unchanged=Remaining
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/threadContext/ThreadContextConfig/propagated=
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/threadContext/ThreadContextConfig/cleared=Buffer,ThreadPriority
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/threadContext/ThreadContextConfig/unchanged=Remaining
 
-org.eclipse.microprofile.concurrency.tck.MPConfigBean.clearAllRemainingThreadContext.propagated=Buffer
+org.eclipse.microprofile.concurrency.tck.MPConfigBean/clearAllRemainingThreadContext/ThreadContextConfig/propagated=Buffer


### PR DESCRIPTION
Pull fixes #120

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>