### PR TITLE
additional clarification for toString javadoc

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -345,6 +345,17 @@ public interface ManagedExecutor extends ExecutorService {
      * the fully qualified name of the injection point from which the container produces the
      * managed executor.</p>
      *
+     * <p>The injection point name must be formatted with the same pattern as MicroProfile Config overrides,
+     * which is the fully qualified class name of the injection point (delimited by <code>.</code>),
+     * followed by the <code>/</code> character, followed by the injection point field name
+     * or the injection point method name followed by <code>/</code> and the parameter position.
+     * For example,</p>
+     *
+     * <pre><code>
+     * org.eclipse.microprofile.examples.MyBean/myExecutor
+     * org.eclipse.microprofile.examples.MyBean/setCompletableFuture/1
+     * </code></pre>
+     *
      * @return a textual representation of the executor.
      */
     String toString();

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -433,6 +433,17 @@ public interface ThreadContext {
      * the fully qualified name of the injection point from which the container produces the instance.
      * </p>
      *
+     * <p>The injection point name must be formatted with the same pattern as MicroProfile Config overrides,
+     * which is the fully qualified class name of the injection point (delimited by <code>.</code>),
+     * followed by the <code>/</code> character, followed by the injection point field name
+     * or the injection point method name followed by <code>/</code> and the parameter position.
+     * For example,</p>
+     *
+     * <pre><code>
+     * org.eclipse.microprofile.examples.MyBean/myThreadContext
+     * org.eclipse.microprofile.examples.MyBean/setContextSnapshot/1
+     * </code></pre>
+     *
      * @return a textual representation of this instance.
      */
     String toString();


### PR DESCRIPTION
Clarify that toString should use the same injection point name as is used to override in MPConfig

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>