### PR TITLE
Possible compromise solution for transaction context defaults

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -109,11 +109,15 @@ public interface ThreadContext {
          * <p>This set replaces the <code>cleared</code> set that was
          * previously specified on the builder instance, if any.</p>
          *
-         * <p>The default set of cleared thread context types is
-         * {@link ThreadContext#TRANSACTION}, which means that a transaction
+         * <p>For example, if the user specifies {@link ThreadContext#TRANSACTION}
+         * in this set, then a transaction
          * is not active on the thread when the action or task runs, such
          * that each action or task is able to independently start and end
          * its own transactional work.</p>
+         *
+         * <p>By default, the set of cleared context is empty, but context clearing
+         * also depends on whether all context types are accounted for in the
+         * {@link #propagated} and {@link #unchanged} sets.
          *
          * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
          * set of cleared context if neither the {@link #propagated} set nor the
@@ -141,10 +145,8 @@ public interface ThreadContext {
          * <p>The default set of propagated thread context types is
          * {@link ThreadContext#ALL_REMAINING}, which includes all available
          * thread context types that support capture and propagation to other
-         * threads, except for those that are explicitly {@link cleared},
-         * which, by default is {@link ThreadContext#TRANSACTION} context,
-         * in which case is suspended from the thread that runs the action or
-         * task.</p>
+         * threads, except for those that are explicitly {@link #cleared}
+         * or {@link #unchanged}.</p>
          *
          * <p>Constants for specifying some of the core context types are provided
          * on {@link ThreadContext}. Other thread context types must be defined

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContextConfig.java
@@ -82,7 +82,8 @@ public @interface ThreadContextConfig {
      * where the action or task executes. The previous context is resumed
      * on the thread after the action or task ends.</p>
      *
-     * <p>By default, the transaction context is cleared/suspended from
+     * <p>For example, if the user specifies {@link ThreadContext#TRANSACTION} in this set,
+     * then when a action or task runs, the current transaction is cleared/suspended from
      * the execution thread so that actions and tasks can start and
      * end transactions of their choosing, to independently perform their
      * own transactional work, as needed.</p>
@@ -103,7 +104,7 @@ public @interface ThreadContextConfig {
      * or if the {@link #propagated} and/or {@link #unchanged} set
      * includes one or more of the same types as this set.</p>
      */
-    String[] cleared() default { ThreadContext.TRANSACTION };
+    String[] cleared() default {};
 
     /**
      * <p>Defines the set of thread context types to capture from the thread
@@ -113,10 +114,8 @@ public @interface ThreadContextConfig {
      * <p>The default set of propagated thread context types is
      * {@link ThreadContext#ALL_REMAINING}, which includes all available
      * thread context types that support capture and propagation to other
-     * threads, except for those that are explicitly {@link cleared},
-     * which, by default is {@link ThreadContext#TRANSACTION} context,
-     * in which case is suspended from the thread that runs the action or
-     * task.</p>
+     * threads, except for those that are explicitly {@link #cleared}
+     * or {@link #unchanged}.</p>
      *
      * <p>Constants for specifying some of the core context types are provided
      * on {@link ThreadContext}. Other thread context types must be defined
@@ -181,7 +180,7 @@ public @interface ThreadContextConfig {
         public final class Literal extends AnnotationLiteral<ThreadContextConfig> implements ThreadContextConfig {
 
             public static final Literal DEFAULT_INSTANCE = 
-                of(new String[]{ThreadContext.TRANSACTION}, new String[]{}, new String[]{ThreadContext.ALL_REMAINING});;
+                of(new String[]{}, new String[]{}, new String[]{ThreadContext.ALL_REMAINING});
 
             private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ThreadContextProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ThreadContextProvider.java
@@ -61,7 +61,9 @@ public interface ThreadContextProvider {
      * @return immutable snapshot of the provided type of context, captured from the
      *         current thread. NULL must be returned if the thread context provider
      *         does not support capturing context from the current thread and
-     *         propagating it to other threads.
+     *         propagating it to other threads, in which case the MicroProfile Concurrency
+     *         implementation must in turn raise <code>UnsupportedOperationException</p>
+     *         to the caller.
      */
     ThreadContextSnapshot currentContext(Map<String, String> props);
 

--- a/spec/src/main/asciidoc/examples.asciidoc
+++ b/spec/src/main/asciidoc/examples.asciidoc
@@ -56,7 +56,9 @@ This section includes some additional examples of spec usage.
 
 [source, java]
 ----
-    threadContext = ThreadContext.builder().build();
+    threadContext = ThreadContext.builder()
+                        .propagated(ThreadContext.APPLICATION)
+                        .build();
     contextSnapshot = threadContext.currentContextExecutor();
 
     ... on some other thread,

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -21,7 +21,7 @@ If a MicroProfile Config implementation is available, MicroProfile Config can be
 
 === Application usage of MicroProfile Config
 
-Applications can use MicroProfile Config in the standard way to enable configuration attributes of the `ManagedExecutor` and `ThreadContext` builders to be overriden.  For example,
+Applications can use MicroProfile Config in the standard way to enable configuration attributes of the `ManagedExecutor` and `ThreadContext` builders to be overridden.  For example,
 
 [source, java]
 ----
@@ -112,7 +112,7 @@ MicroProfile Config can be used to override array type properties (`propagated`,
 - Array elements can be any thread context type constant value from ThreadContext (such as `Security`, `Application`, or `Remaining`).
 - The usual rules from the MicroProfile Config specification apply, such as escaping special characters.
 
-For example, we can start with the following injection point, which has the default configuration for `ThreadContext`. This means clearing the `Transaction` context, leaving no context type unchanged, and propagating all `Remaining` context types,
+For example, we can start with the following injection point, which has the default configuration for `ThreadContext`. This means propagating all known types of context,
 
 [source, java]
 ----
@@ -124,12 +124,12 @@ public class MyBean {
 }
 ----
 
-If the user wishes to override the above to propagate exactly 2 context types (`Application` and `CDI`), clear nothing, and leave all `Remaining` types unchanged, then they could configure the following MicroProfile Config properties,
+If the user wishes to override the above to instead propagate no context types, clearing two context types (`Security` and `Transaction`), and leave all `Remaining` types unchanged, then they could configure the following MicroProfile Config properties,
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/propagated=Application,CDI
-org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/cleared=
+org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/propagated=
+org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/cleared=Security,Transaction
 org.eclipse.microprofile.example.MyBean/contextPropagator/ThreadContextConfig/unchanged=Remaining
 ----
 

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigTest.java
@@ -430,7 +430,7 @@ public class MPConfigTest extends Arquillian {
      */
     @Test
     public void overrideContextPropagationForThreadContextWithImpliedCleared() throws Exception {
-        // Expected config is propagated=Buffer; cleared=Transaction(with implied Remaining); unchanged=Label
+        // Expected config is propagated=Buffer; cleared={} (implied Remaining); unchanged=Label
         Assert.assertNotNull(clearAllRemainingThreadContext,
                 "Unable to inject ThreadContext qualified by NamedInstance. Cannot run test.");
         
@@ -781,7 +781,7 @@ public class MPConfigTest extends Arquillian {
         ManagedExecutorConfig.Literal managedExecutorConfig = ManagedExecutorConfig.Literal.of(
                 1,
                 -1,
-                new String[] { ThreadContext.ALL_REMAINING }, // cleared 
+                new String[] { ThreadContext.ALL_REMAINING }, // cleared
                 new String[] { Buffer.CONTEXT_NAME, Label.CONTEXT_NAME }); // propagated 
         try {
             instance = cdi.select(ManagedExecutor.class, managedExecutorConfig);
@@ -795,7 +795,7 @@ public class MPConfigTest extends Arquillian {
         managedExecutorConfig = ManagedExecutorConfig.Literal.of(
                 1,
                 4,
-                new String[] { ThreadPriorityContextProvider.THREAD_PRIORITY, Buffer.CONTEXT_NAME, ThreadContext.TRANSACTION }, // cleared 
+                new String[] { ThreadPriorityContextProvider.THREAD_PRIORITY, Buffer.CONTEXT_NAME, ThreadContext.TRANSACTION }, // cleared
                 new String[] { ThreadContext.ALL_REMAINING }); // propagated 
         try {
             instance = cdi.select(ManagedExecutor.class, namedInstance, managedExecutorConfig);
@@ -838,7 +838,7 @@ public class MPConfigTest extends Arquillian {
 
         // Try matching annotation values before MP Config is applied,
         ThreadContextConfig.Literal threadContextConfig = ThreadContextConfig.Literal.of(
-                new String[] { ThreadContext.TRANSACTION }, // cleared 
+                new String[] { }, // cleared
                 new String[] { ThreadContext.ALL_REMAINING }, // propagated
                 new String[] { Label.CONTEXT_NAME }); // unchanged
         try {
@@ -851,7 +851,7 @@ public class MPConfigTest extends Arquillian {
 
         // Try matching annotation values after MP Config is applied,
         threadContextConfig = ThreadContextConfig.Literal.of(
-                new String[] { ThreadContext.TRANSACTION }, // cleared 
+                new String[] { }, // cleared
                 new String[] { Buffer.CONTEXT_NAME }, // propagated
                 new String[] { Label.CONTEXT_NAME }); // unchanged
         try {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIBean.java
@@ -432,7 +432,7 @@ public class CDIBean {
     /**
      * When the container creates a ThreadContext for an injection point that lacks a ThreadContextConfig annotation,
      * its configuration is equivalent to ThreadContext.builder().build(), which is that all available thread context
-     * types are propagated, except for Transaction context, which is cleared.
+     * types are propagated.
      */
     public void testInjectThreadContextNoConfig() {
         Assert.assertNotNull(defaultContext,
@@ -472,7 +472,7 @@ public class CDIBean {
     /**
      * When the container creates a ThreadContext for an injection point with an empty ThreadContextConfig annotation,
      * its configuration is equivalent to ThreadContext.builder().build(), which is that all available thread context
-     * types are propagated, except for Transaction context, which is cleared.
+     * types are propagated.
      */
     public void testInjectThreadContextEmptyConfig() throws Exception {
         Assert.assertNotNull(defaultContextWithEmptyAnno,


### PR DESCRIPTION
Update spec per compromise that transaction context propagation is default for ThreadContext but remains cleared for ManagedExecutor.

fixes #124 if the compromise solution is decided upon.  At this point, discussion is still ongoing (still hoping that others will come to the conclusion that the current spec behavior of default configuration being to clear transaction context is best for ThreadContext as well as ManagedExecutor).

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>