### PR TITLE
remove configuration defaults for context propagation, and allow to be specified via MP Config

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -33,13 +33,14 @@ import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
  *
  * <p>Example usage:</p>
  * <pre>
- * <code>&commat;Inject</code> ManagedExecutor executor;
+ * <code>ManagedExecutor executor = ManagedExecutor.builder().propagated(ThreadContext.APPLICATION).cleared(ThreadContext.ALL_REMAINING).build();
  * ...
  * CompletableFuture&lt;Integer&gt; future = executor
  *    .supplyAsync(supplier)
  *    .thenApplyAsync(function1)
  *    .thenApply(function2)
  *    ...
+ * </code>
  * </pre>
  *
  * <p>This specification allows for managed executors that propagate thread context as well as for
@@ -154,6 +155,9 @@ public interface ManagedExecutor extends ExecutorService {
          *         {@link #cleared} set and the {@link #propagated} set</li>
          *         <li>if a thread context type that is configured to be
          *         {@link #cleared} or {@link #propagated} is unavailable</li>
+         *         <li>if context configuration is neither specified on the builder
+         *         nor via MicroProfile Config, and the builder implementation lacks
+         *         vendor-specific defaults of its own.</li>
          *         <li>if more than one provider provides the same thread context
          *         {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}
          *         </li>
@@ -169,8 +173,8 @@ public interface ManagedExecutor extends ExecutorService {
          * <p>This set replaces the <code>cleared</code> set that was previously
          * specified on the builder instance, if any.</p>
          *
-         * <p>The default set of cleared thread context types is
-         * {@link ThreadContext#TRANSACTION}, which means that a transaction
+         * <p>For example, if the user specifies
+         * {@link ThreadContext#TRANSACTION} in this set, then a transaction
          * is not active on the thread when the action or task runs, such
          * that each action or task is able to independently start and end
          * its own transactional work.</p>
@@ -197,14 +201,6 @@ public interface ManagedExecutor extends ExecutorService {
          *
          * <p>This set replaces the <code>propagated</code> set that was
          * previously specified on the builder instance, if any.</p>
-         *
-         * <p>The default set of propagated thread context types is
-         * {@link ThreadContext#ALL_REMAINING}, which includes all available
-         * thread context types that support capture and propagation to other
-         * threads, except for those that are explicitly {@link cleared},
-         * which, by default is {@link ThreadContext#TRANSACTION} context,
-         * in which case is suspended from the thread that runs the action or
-         * task.</p>
          *
          * <p>Constants for specifying some of the core context types are provided
          * on {@link ThreadContext}. Other thread context types must be defined

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ManagedExecutor.java
@@ -188,6 +188,11 @@ public interface ManagedExecutor extends ExecutorService {
          * by the specification that defines the context type or by a related
          * MicroProfile specification.</p>
          *
+         * <p>The MicroProfile Config property, <code>ManagedExecutor/cleared</code>,
+         * establishes a default that is used if no value is otherwise specified.
+         * The value of the MicroProfile Config property can be the empty string
+         * or a comma separated list of context type constant values.</p>
+         *
          * @param types types of thread context to clear from threads that run
          *        actions and tasks.
          * @return the same builder instance upon which this method is invoked.
@@ -207,6 +212,11 @@ public interface ManagedExecutor extends ExecutorService {
          * by the specification that defines the context type or by a related
          * MicroProfile specification.</p>
          *
+         * <p>The MicroProfile Config property, <code>ManagedExecutor/propagated</code>,
+         * establishes a default that is used if no value is otherwise specified.
+         * The value of the MicroProfile Config property can be the empty string
+         * or a comma separated list of context type constant values.</p>
+         *
          * <p>Thread context types which are not otherwise included in this set
          * are cleared from the thread of execution for the duration of the
          * action or task.</p>
@@ -225,7 +235,9 @@ public interface ManagedExecutor extends ExecutorService {
          * the <code>ManagedExecutor</code> starts executing them.</p>
          *
          * <p>The default value of <code>-1</code> indicates no upper bound,
-         * although practically, resource constraints of the system will apply.</p>
+         * although practically, resource constraints of the system will apply.
+         * You can switch the default by specifying the MicroProfile Config
+         * property, <code>ManagedExecutor/maxAsync</code>.</p>
          *
          * @param max upper bound on async completion stage actions and executor tasks.
          * @return the same builder instance upon which this method is invoked.
@@ -239,7 +251,9 @@ public interface ManagedExecutor extends ExecutorService {
          * if no space in the queue is available to accept them.</p>
          *
          * <p>The default value of <code>-1</code> indicates no upper bound,
-         * although practically, resource constraints of the system will apply.</p>
+         * although practically, resource constraints of the system will apply.
+         * You can switch the default by specifying the MicroProfile Config
+         * property, <code>ManagedExecutor/maxQueued</code>.</p>
          *
          * @param max upper bound on async actions and tasks that can be queued.
          * @return the same builder instance upon which this method is invoked.

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/NamedInstance.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/NamedInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,10 +36,13 @@ import javax.inject.Qualifier;
  * <p>This annotation can be used in combination with the {@link ManagedExecutorConfig} or {@link ThreadContextConfig}
  * annotation to define a new instance. For example,</p>
  *
- * <pre><code> &commat;Inject &commat;NamedInstance("myExecutor") &commat;ManagedExecutorConfig(maxAsync=10)
+ * <pre><code> &commat;Inject &commat;NamedInstance("myExecutor") &commat;ManagedExecutorConfig(propagated = ThreadContext.SECURITY,
+ *                                                             cleared = ThreadContext_ALL_REMAINING)
  * ManagedExecutor myExecutor;
  *
- * &commat;Inject &commat;NamedInstance("myContext") &commat;ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.CDI })
+ * &commat;Inject &commat;NamedInstance("myContext") &commat;ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.CDI },
+ *                                                          cleared = ThreadContext.TRANSACTION,
+ *                                                          unchanged = ThreadContext.ALL_REMAINING)
  * ThreadContext myThreadContext;
  * </code></pre>
  *
@@ -57,7 +60,7 @@ import javax.inject.Qualifier;
  * defining its own scope, producer, and disposer. For example,</p>
  *
  * <pre><code> &commat;Produces &commat;ApplicationScoped &commat;NamedInstance("exec2")
- * ManagedExecutor exec2 = ManagedExecutor.builder().maxAsync(5).build();
+ * ManagedExecutor exec2 = ManagedExecutor.builder().propagated(ThreadContext.SECURITY).cleared(ThreadContext.ALL_REMAINING).build();
  *
  * public void shutdown(&commat;Disposes &commat;NamedInstance("exec2") ManagedExecutor executor) {
  *     executor.shutdown();

--- a/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/ThreadContext.java
@@ -132,6 +132,11 @@ public interface ThreadContext {
          * by the specification that defines the context type or by a related
          * MicroProfile specification.</p>
          *
+         * <p>The MicroProfile Config property, <code>ThreadContext/cleared</code>,
+         * establishes a default that is used if no value is otherwise specified.
+         * The value of the MicroProfile Config property can be the empty string
+         * or a comma separated list of context type constant values.</p>
+         *
          * @param types types of thread context to clear from threads that run
          *        actions and tasks.
          * @return the same builder instance upon which this method is invoked.
@@ -150,6 +155,11 @@ public interface ThreadContext {
          * on {@link ThreadContext}. Other thread context types must be defined
          * by the specification that defines the context type or by a related
          * MicroProfile specification.</p>
+         *
+         * <p>The MicroProfile Config property, <code>ThreadContext/propagated</code>,
+         * establishes a default that is used if no value is otherwise specified.
+         * The value of the MicroProfile Config property can be the empty string
+         * or a comma separated list of context type constant values.</p>
          *
          * <p>Thread context types which are not otherwise included in this set or
          * in the {@link #unchanged} set are cleared from the thread of execution
@@ -172,6 +182,11 @@ public interface ThreadContext {
          * on {@link ThreadContext}. Other thread context types must be defined
          * by the specification that defines the context type or by a related
          * MicroProfile specification.</p>
+         *
+         * <p>The MicroProfile Config property, <code>ThreadContext/unchanged</code>,
+         * establishes a default that is used if no value is otherwise specified.
+         * The value of the MicroProfile Config property can be the empty string
+         * or a comma separated list of context type constant values.</p>
          *
          * <p>The configuration of <code>unchanged</code> context is provided for
          * advanced patterns where it is desirable to leave certain context types

--- a/spec/src/main/asciidoc/builders.asciidoc
+++ b/spec/src/main/asciidoc/builders.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ public class ExampleServlet extends HttpServlet {
     public void init(ServletConfig config) {
         threadContext = ThreadContext.builder()
                             .propagated(ThreadContext.APPLICATION, ThreadContext.SECURITY)
+                            .unchanged()
                             .cleared(ThreadContext.ALL_REMAINING)
                             .build();
     }

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,17 +22,7 @@ Injection points with the `@NamedInstance` qualifier have a name that is explici
 Injection points that have no CDI qualifier on them have a unique name which is deduced from the injection point itself.
 Container provides, per unique name, an instance of either `ManagedExecutor` and/or `ThreadContext` unless the application specifies a CDI producer with `@NamedInstance` qualifier, given unique name and respective type.
 
-=== Injecting `ManagedExecutor`
-
-The simplest use case is a new executor instance per injection point, where the configuration is equivalent to the default values of the `@ManagedExecutorConfig` annotation.
-
-[source, java]
-----
-@Inject
-ManagedExecutor executor;
-----
-
-==== Configuring `ManagedExecutor`
+==== Injecting and Configuring `ManagedExecutor`
 
 Oftentimes there is a need to configure the executor instance to limit the number of asynchronous tasks that it can start or define which contexts to propagate.
 The `@ManagedExecutorConfig` annotation allows you to configure all aspects of an injected `ManagedExecutor` instance.
@@ -41,7 +31,7 @@ Note that when using this annotation only, new instance of `ManagedExecutor` is 
 [source, java]
 ----
 @Inject
-@ManagedExecutorConfig(maxAsync = 5, propagated = ThreadContext.SECURITY)
+@ManagedExecutorConfig(maxAsync = 5, propagated = ThreadContext.SECURITY, cleared = ThreadContext.ALL_REMAINING)
 ManagedExecutor configuredExecutor;
 ----
 
@@ -59,7 +49,7 @@ public class MyFirstBean {
 
   @Inject
   @NamedInstance("myExecutor")
-  @ManagedExecutorConfig(maxAsync = 5, propagated = ThreadContext.SECURITY)
+  @ManagedExecutorConfig(maxAsync = 5, propagated = ThreadContext.SECURITY, cleared = ThreadContext.ALL_REMAINING)
   ManagedExecutor executor;
 
 }
@@ -74,42 +64,9 @@ public class MySecondBean {
 }
 ----
 
-Since the configuration of `ManagedExecutor` is optional, a shared `ManagedExecutor` with default configuration is also a possibility.
-
-[source, java]
-----
-@ApplicationScoped
-public class FooBean {
-
-  @Inject
-  @NamedInstance("sharedDefaultME")
-  ManagedExecutor executor;
-
-}
-
-@ApplicationScoped
-public class BarBean {
-
-  @Inject
-  @NamedInstance("sharedDefaultME")
-  ManagedExecutor sharedExecutor;
-
-}
-----
-
 If multiple configurations of `ManagedExecutor` are assigned the same name, the container detects it and raises a `javax.enterprise.inject.spi.DefinitionException`.
 
-=== Injecting `ThreadContext`
-
-The simplest use case is a new `ThreadContext` instance per injection point, where the configuration is equivalent to the default values of the `@ThreadContextConfig` annotation.
-
-[source, java]
-----
-@Inject
-ThreadContext context;
-----
-
-==== Configuring `ThreadContext`
+==== Injecting and Configuring `ThreadContext`
 
 Oftentimes there is a need to configure the `ThreadContext` instance to specify which contexts to propagate.
 The `@ThreadContextConfig` annotation allows you to configure all aspects of an injected `ThreadContext` instance.
@@ -118,7 +75,7 @@ Note that when using this annotation only, new instance of `ThreadContext` is cr
 [source, java]
 ----
 @Inject
-@ThreadContextConfig(propagated = ThreadContext.SECURITY)
+@ThreadContextConfig(propagated = ThreadContext.SECURITY, unchanged = {}, cleared = ThreadContext.ALL_REMAINING)
 ThreadContext configuredContext;
 ----
 
@@ -136,7 +93,7 @@ public class MyFirstBean {
 
   @Inject
   @NamedInstance("myThreadContext")
-  @ThreadContextConfig(propagated = ThreadContext.SECURITY)
+  @ThreadContextConfig(propagated = ThreadContext.SECURITY, unchanged = {}, cleared = ThreadContext.ALL_REMAINING)
   ThreadContext context;
 
 }
@@ -147,29 +104,6 @@ public class MySecondBean {
   @Inject
   @NamedInstance("myThreadContext")
   ManagedExecutor sharedContext;
-
-}
-----
-
-Since the configuration of `ThreadContext` is optional, a shared `ThreadContext` with default configuration is also a possibility.
-
-[source, java]
-----
-@ApplicationScoped
-public class FooBean {
-
-  @Inject
-  @NamedInstance("sharedDefaultTC")
-  ThreadContext context;
-
-}
-
-@ApplicationScoped
-public class BarBean {
-
-  @Inject
-  @NamedInstance("sharedDefaultTC")
-  ThreadContext sharedContext;
 
 }
 ----

--- a/spec/src/main/asciidoc/examples.asciidoc
+++ b/spec/src/main/asciidoc/examples.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ This section includes some additional examples of spec usage.
 ----
     threadContext = ThreadContext.builder()
                         .propagated(ThreadContext.SECURITY)
+                        .unchanged()
                         .cleared(ThreadContext.ALL_REMAINING)
                         .build();
 
@@ -54,6 +55,7 @@ This section includes some additional examples of spec usage.
 ----
     threadContext = ThreadContext.builder()
                         .propagated(ThreadContext.SECURITY)
+                        .unchanged()
                         .cleared(ThreadContext.ALL_REMAINING)
                         .build();
 
@@ -70,7 +72,11 @@ This section includes some additional examples of spec usage.
 
 [source, java]
 ----
-    threadContext = ThreadContext.builder().build();
+    threadContext = ThreadContext.builder()
+                                 .cleared(ThreadContext.TRANSACTION)
+                                 .unchanged(ThreadContext.SECURITY)
+                                 .propagated(ThreadContext.ALL_REMAINING)
+                                 .build();
     contextSnapshot = threadContext.currentContextExecutor();
 
     ... on some other thread,

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -17,11 +17,11 @@
 [[concurrencympconfig]]
 == Integration with MicroProfile Config
 
-If a MicroProfile Config implementation is available, MicroProfile Config can be used to override configuration attributes of `ManagedExecutor` and `ThreadContext`.  This is true of instances that are built by the application as well as those produced by the container for injection as CDI beans.  The former involves standard usage of MicroProfile Config.  The latter relies upon the convention of defining MicroProfile Config property names that correspond to the fully qualified name of the injection point for which the instance is produced.  For `ManagedExecutor` and `ThreadContext` instances produced by the container, MicroProfie Config is applied statically. These instances will not dynamically respond to MicroProfile Config changes made after they are produced.
+If a MicroProfile Config implementation is available, MicroProfile Config can be used to override configuration attributes of `ManagedExecutor` and `ThreadContext`.  This is true of instances that are built by the application as well as those produced by the container for injection as CDI beans.  The former involves standard usage of MicroProfile Config.  The latter relies upon the convention of defining MicroProfile Config property names that correspond to the fully qualified name of the injection point for which the instance is produced.  For `ManagedExecutor` and `ThreadContext` instances produced by the container, MicroProfile Config is applied statically. These instances will not dynamically respond to MicroProfile Config changes made after they are produced.
 
 === Application usage of MicroProfile Config
 
-Applications can use MicroProfile Config in the standard way to enable configuration attributes of the `ManagedExecutor` and `ThreadContext` builders to be overriden.  For example,
+Applications can use MicroProfile Config in the standard way to enable configuration attributes of the `ManagedExecutor` and `ThreadContext` builders to be overridden.  For example,
 
 [source, java]
 ----
@@ -29,7 +29,12 @@ Applications can use MicroProfile Config in the standard way to enable configura
 ManagedExecutor createExecutor(
     @ConfigProperty(name="exec1.maxAsync", defaultValue="5") Integer a,
     @ConfigProperty(name="exec1.maxQueued", defaultValue="20") Integer q) {
-    return ManagedExecutor.builder().maxAsync(a).maxQueued(q).build();
+    return ManagedExecutor.builder()
+                          .maxAsync(a)
+                          .maxQueued(q)
+                          .propagated(ThreadContext.SECURITY, ThreadContext.APPLICATION)
+                          .cleared(ThreadContext.ALL_REMAINING)
+                          .build();
 }
 ----
 
@@ -43,7 +48,7 @@ exec1.maxQueued=15
 
 === Container usage of MicroProfile Config
 
-The container produces an instance per unqualified `ManagedExecutor` injection point, which may optionally be annotated with the `@ManagedExecutorConfig` annotation to supply default configuration. The container also produces an instance per `ManagedExecutor` injection point that is annotated with both the `@ManagedExecutorConfig` annotation and the `@NamedInstance` qualifier. And likewise for `ThreadContext` and `@ThreadContextConfig`.
+The container produces an instance per `ManagedExecutor` injection point that is annotated with the `@ManagedExecutorConfig` annotation. And likewise for `ThreadContext` and `@ThreadContextConfig`.
 
 In each of these cases, MicroProfile Config can be used to override the configuration of the instance that is produced by the container.
 
@@ -54,13 +59,10 @@ To override a configuration attribute of an instance that is produced for inject
 package org.eclipse.microprofile.example;
 ...
 public class MyBean {
-    @Inject
-    ManagedExecutor exec2;
-
-    @Inject @ManagedExecutorConfig(maxAsync=3)
+    @Inject @ManagedExecutorConfig(maxAsync=3, propagated=ThreadContext.APPLICATION, cleared=ThreadContext.ALL_REMAINING)
     ManagedExecutor exec3;
 
-    @Inject @NamedInstance("executor4") @ManagedExecutorConfig(maxAsync=4)
+    @Inject @NamedInstance("executor4") @ManagedExecutorConfig(maxAsync=4, propagated=ThreadContext.SECURITY, cleared=ThreadContext.ALL_REMAINING)
     ManagedExecutor exec4;
 
     @Inject @NamedInstance("executor4")
@@ -70,12 +72,9 @@ public class MyBean {
 
 [source, text]
 ----
-org.eclipse.microprofile.example.MyBean/exec2/ManagedExecutorConfig/maxAsync=5
 org.eclipse.microprofile.example.MyBean/exec3/ManagedExecutorConfig/maxAsync=6
 org.eclipse.microprofile.example.MyBean/exec4/ManagedExecutorConfig/maxAsync=7
 ----
-
-Note that `exec2` can be overridden with `ManagedExecutorConfig` attributes even though it does not explicitly declare a `ManagedExecutorConfig` annotation.
 
 Note that `org.eclipse.microprofile.example.MyBean/exec4/ManagedExecutorConfig/maxAsync` overrides the configuration of the instance that is produced for injection into `exec4`. This same instance is injected into `exec5` per the matching `@NamedInstance("executor4")` qualifier.  It is incorrect to specify `org.eclipse.microprofile.example.MyBean/exec5/ManagedExecutorConfig/maxAsync`, which will not apply to `exec5`.
 
@@ -87,7 +86,10 @@ package org.eclipse.microprofile.example;
 ...
 public class MyBean {
     @Produces @ApplicationScoped @NamedInstance("executor6")
-    ManagedExecutor createExecutor(@ManagedExecutorConfig(maxAsync=6) ManagedExecutor exec) {
+    ManagedExecutor createExecutor(@ManagedExecutorConfig(maxAsync=6,
+                                                          propagated=ThreadContext.CDI,
+                                                          cleared=ThreadContext.ALL_REMAINING)
+                                   ManagedExecutor exec) {
         return exec;
     }
 
@@ -112,14 +114,14 @@ MicroProfile Config can be used to override array type properties (`propagated`,
 - Array elements can be any thread context type constant value from ThreadContext (such as `Security`, `Application`, or `Remaining`).
 - The usual rules from the MicroProfile Config specification apply, such as escaping special characters.
 
-For example, we can start with the following injection point, which has the default configuration for `ThreadContext`. This means clearing the `Transaction` context, leaving no context type unchanged, and propagating all `Remaining` context types,
+For example, we can start with the following injection point, which is configured to clear the `Transaction` context, leave no context type unchanged, and propagate all `Remaining` context types,
 
 [source, java]
 ----
 package org.eclipse.microprofile.example;
 ...
 public class MyBean {
-    @Inject
+    @Inject @ThreadContextConfig(cleared=ThreadContext.TRANSACTION, unchanged={}, propagated=ThreadContext.ALL_REMAINING)
     ThreadContext contextPropagator;
 }
 ----

--- a/spec/src/main/asciidoc/mpconfig.asciidoc
+++ b/spec/src/main/asciidoc/mpconfig.asciidoc
@@ -15,9 +15,52 @@
 //
 
 [[concurrencympconfig]]
-== Integration with MicroProfile Config
+== Establishing default values with MicroProfile Config
 
-If a MicroProfile Config implementation is available, MicroProfile Config can be used to override configuration attributes of `ManagedExecutor` and `ThreadContext`.  This is true of instances that are built by the application as well as those produced by the container for injection as CDI beans.  The former involves standard usage of MicroProfile Config.  The latter relies upon the convention of defining MicroProfile Config property names that correspond to the fully qualified name of the injection point for which the instance is produced.  For `ManagedExecutor` and `ThreadContext` instances produced by the container, MicroProfile Config is applied statically. These instances will not dynamically respond to MicroProfile Config changes made after they are produced.
+If a MicroProfile Config implementation is available, MicroProfile Config can be used to establish default values for configuration attributes of `ManagedExecutor` and `ThreadContext`. This allows the application to bypass configuration of one or more attributes when using the builders to create instances.
+
+For example, you could specify MicroProfile Config properties as follows to establish a set of defaults for `ManagedExecutor`,
+
+[source, text]
+----
+ManagedExecutor/propagated=Remaining
+ManagedExecutor/cleared=Transaction
+ManagedExecutor/maxAsync=10
+ManagedExecutor/maxQueued=-1
+----
+
+With these defaults in place, the application can create a `ManagedExecutor` instance without specifying some of the configuration attributes,
+
+[source, java]
+----
+executor = ManagedExecutor.builder().maxAsync(5).build();
+----
+
+In the code above, the application specifies only the `maxAsync` attribute, limiting actions and tasks requested to run async to at most 5 running at any given time. The other configuration attributes are defaulted as specified in MicroProfile config, with no upper bound on queued tasks, Transaction context cleared, and all other context types propagated.
+
+As another example, the following MicroProfile Config properties establish defaults for `ThreadContext`,
+
+[source, text]
+----
+ThreadContext/propagated=
+ThreadContext/cleared=Security,Transaction
+ThreadContext/unchanged=Remaining
+----
+
+With these defaults in place, the application can create a `ThreadContext` instance without specifying some of the configuration attributes,
+
+[source, java]
+----
+cdiContextPropagator = ThreadContext.builder()
+                                    .propagated(ThreadContext.CDI)
+                                    .build();
+----
+
+In the code above, the application specifies only the `propagated` attribute, indicating that only CDI context is propagated. The other configuration attributes inherit the defaults, which includes clearing Security and Transaction context and leaving all other thread context types unchanged.
+
+== Overriding configured values with MicroProfile Config
+
+MicroProfile Config can also be used to override configured values. This is true of instances that are built by the application as well as those produced by the container for injection as CDI beans.  The former involves standard usage of MicroProfile Config.  The latter relies upon the convention of defining MicroProfile Config property names that correspond to the fully qualified name of the injection point for which the instance is produced.  For `ManagedExecutor` and `ThreadContext` instances produced by the container, MicroProfile Config is applied statically. These instances will not dynamically respond to MicroProfile Config changes made after they are produced.
 
 === Application usage of MicroProfile Config
 

--- a/spec/src/main/asciidoc/overview.asciidoc
+++ b/spec/src/main/asciidoc/overview.asciidoc
@@ -55,43 +55,18 @@ Instances of `ManagedExecutor` and `ThreadContext` can be constructed via builde
 ----
     ManagedExecutor executor = ManagedExecutor.builder()
         .propagated(ThreadContext.APPLICATION)
+        .cleared(ThreadContext.ALL_REMAINING)
         .maxAsync(5)
         .build();
 
     ThreadContext threadContext = ThreadContext.builder()
         .propagated(ThreadContext.APPLICATION, ThreadContext.CDI)
+        .unchanged()
         .cleared(ThreadContext.ALL_REMAINING)
         .build();
 ----
 
 Applications should shut down instances of `ManagedExecutor` that they build after they are no longer needed. The shutdown request serves as a signal notifying the container that resources can be safely cleaned up.
-
-=== Injection
-
-Instances of `ManagedExecutor` and `ThreadContext` can be injected into CDI beans via the `@Inject` annotation.
-Injection points with the `@NamedInstance` qualifier have a name that is explicitly declared by the qualifier.
-Injection points that have no CDI qualifier on them have a unique name which is deduced from the injection point itself.
-Container provides, per unique name, an instance of either `ManagedExecutor` and/or `ThreadContext` unless the application specifies a CDI producer with `@NamedInstance` qualifier, given unique name and respective type.
- for example:
-
-[source, java]
-----
-    @Inject ManagedExecutor executor;
-    @Inject ThreadContext threadContext;
-    ...
-    CompletableFuture<Integer> stage = executor
-        .supplyAsync(supplier1)
-        .thenApplyAsync(function1)
-        .thenApply(function2);
-    ...
-    threadContext.withContextCapture(unmanagedCompletionStage)
-        .supply(supplier1)
-        .thenApply(function1)
-        .thenApply(function2);
-----
-
-In the absence of other qualifiers and annotations, the container creates and injects a new default instance of `ManagedExecutor` or `ThreadContext` per injection point, as shown above.
-The configuration of these instances is equivalent to the default values of `@ManagedExecutorConfig` and `@ThreadContextConfig`.
 
 === Injection of Configured Instances
 
@@ -101,7 +76,7 @@ With just the config annotation in place, every injection point is assigned a ne
 [source, java]
 ----
     @Inject 
-    @ManagedExecutorConfig(maxAsync = 5, propagated = ThreadContext.SECURITY)
+    @ManagedExecutorConfig(maxAsync = 5, propagated = ThreadContext.SECURITY, cleared = ThreadContext.ALL_REMAINING)
     ManagedExecutor configuredExecutor;
     ...
     CompletableFuture<Long> stage = configuredExecutor
@@ -116,7 +91,7 @@ Or similarly:
 [source, java]
 ----
     @Inject 
-    @ThreadContextConfig(propagated = ThreadContext.SECURITY)
+    @ThreadContextConfig(propagated = ThreadContext.SECURITY, unchanged = {}, cleared = ThreadContext.ALL_REMAINING)
     ThreadContext threadContext;
     ...
     threadContext.withContextCapture(unmanagedCompletionStage)
@@ -135,7 +110,8 @@ The other injection points, `executor2` and `executor3`, share the same `Managed
 ----
     @Inject
     @NamedInstance("myExec")
-    @ManagedExecutorConfig(propagated = { ThreadContext.SECURITY, ThreadContext.APPLICATION })
+    @ManagedExecutorConfig(propagated = { ThreadContext.SECURITY, ThreadContext.APPLICATION },
+                           cleared = ThreadContext.ALL_REMAINING)
     ManagedExecutor executor1;
     ... // in some other bean
     @Inject

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -48,7 +48,8 @@ Use CDI to inject a `ManagedExecutor` or `ThreadContext` service:
 [source,java]
 ----
 public class MyBean {
-    @Inject ManagedExecutor executor;
+    @Inject @ManagedExecutorConfig(propagated = ThreadContext.APPLICATION, cleared = ThreadContext.ALL_REMAINING)
+    ManagedExecutor executor;
 ----
 
 Or you can create one using a builder:
@@ -57,6 +58,7 @@ Or you can create one using a builder:
 ----
     ManagedExecutor executor = ManagedExecutor.builder()
                        .propagated(ThreadContext.APPLICATION, ThreadContext.CDI)
+                       .cleared(ThreadContext.ALL_REMAINING)
                        .maxAsync(5)
                        .build();
 ----

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/MPConfigBean.java
@@ -66,16 +66,21 @@ public class MPConfigBean {
     // microprofile-config.properties overrides this with propagated=Buffer
     @Inject @NamedInstance("clearAllRemainingThreadContext") @ThreadContextConfig(
             propagated = ThreadContext.ALL_REMAINING,
+            cleared = ThreadContext.TRANSACTION,
             unchanged = Label.CONTEXT_NAME)
     protected ThreadContext clearAllRemainingThreadContext;
 
     // microprofile-config.properties overrides this with propagated=<unconfigured>; cleared=Buffer,ThreadPriority; unchanged=Remaining
-    @Inject
+    @Inject @ThreadContextConfig(
+            propagated = ThreadContext.ALL_REMAINING,
+            cleared = {},
+            unchanged = {})
     protected ThreadContext threadContext;
 
     // microprofile-config.properties overrides exec parameter with maxAsync=1
     @Produces @ApplicationScoped @NamedInstance("producedExecutor")
-    protected ManagedExecutor createExecutor(@ManagedExecutorConfig(maxQueued = 5) ManagedExecutor exec) {
+    protected ManagedExecutor createExecutor(
+            @ManagedExecutorConfig(maxQueued = 5, propagated = {}, cleared = ThreadContext.ALL_REMAINING) ManagedExecutor exec) {
         return exec;
     }
 
@@ -84,7 +89,7 @@ public class MPConfigBean {
     protected ThreadContext createThreadContext(
             @NamedInstance("producedExecutor") ManagedExecutor unused1, // this is here so that we can force parameter position 3 to be used
             @NamedInstance("namedExecutor") ManagedExecutor unused2, // this is here so that we can force parameter position 3 to be used
-            @ThreadContextConfig(propagated=Buffer.CONTEXT_NAME, cleared=ThreadContext.ALL_REMAINING) ThreadContext threadContext) {
+            @ThreadContextConfig(propagated=Buffer.CONTEXT_NAME, cleared=ThreadContext.ALL_REMAINING, unchanged = {}) ThreadContext threadContext) {
         return threadContext;
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -186,6 +186,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void completedFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -288,6 +289,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void completedStageDependentStagesRunWithContext() throws InterruptedException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -446,6 +448,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void contextOfContextualCallableOverridesContextOfManagedExecutor() throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -529,6 +532,7 @@ public class ManagedExecutorTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -617,6 +621,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void contextOfContextualFunctionOverridesContextOfManagedExecutor() throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -714,6 +719,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void contextOfContextualRunnableOverridesContextOfManagedExecutor() throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -792,6 +798,7 @@ public class ManagedExecutorTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -971,6 +978,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void failedFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -1080,6 +1088,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void failedStageDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -1156,6 +1165,8 @@ public class ManagedExecutorTest extends Arquillian {
     public void maxAsync2() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(2)
+                .propagated()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         Phaser barrier = new Phaser(2);
@@ -1210,6 +1221,8 @@ public class ManagedExecutorTest extends Arquillian {
     @Test
     public void maxAsyncInvalidValues() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor.Builder builder = ManagedExecutor.builder();
+        builder.propagated(ThreadContext.ALL_REMAINING);
+        builder.cleared(ThreadContext.TRANSACTION);
 
         try {
             builder.maxAsync(-10);
@@ -1256,6 +1269,8 @@ public class ManagedExecutorTest extends Arquillian {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(1)
                 .maxQueued(3)
+                .propagated()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         Phaser barrier = new Phaser(1);
@@ -1326,7 +1341,9 @@ public class ManagedExecutorTest extends Arquillian {
      */
     @Test
     public void maxQueuedInvalidValues() throws ExecutionException, InterruptedException, TimeoutException {
-        ManagedExecutor.Builder builder = ManagedExecutor.builder();
+        ManagedExecutor.Builder builder = ManagedExecutor.builder()
+                .propagated()
+                .cleared(ThreadContext.ALL_REMAINING);
 
         try {
             builder.maxQueued(-2);
@@ -1368,6 +1385,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void newIncompleteFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -1621,6 +1639,8 @@ public class ManagedExecutorTest extends Arquillian {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(1)
                 .maxQueued(4)
+                .propagated()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         Phaser barrier = new Phaser(1);
@@ -1769,6 +1789,8 @@ public class ManagedExecutorTest extends Arquillian {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(1)
                 .maxQueued(10)
+                .propagated()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         Phaser barrier = new Phaser(1);
@@ -1933,6 +1955,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void runAsyncStageAndDependentStagesRunWithContext() throws ExecutionException, InterruptedException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -2169,6 +2192,7 @@ public class ManagedExecutorTest extends Arquillian {
     public void supplyAsyncStageAndDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -2281,6 +2305,7 @@ public class ManagedExecutorTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -2350,6 +2375,7 @@ public class ManagedExecutorTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -2410,6 +2436,7 @@ public class ManagedExecutorTest extends Arquillian {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(1)
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         // Verify that maxAsync=1 is enforced by recording the thread id upon which
@@ -2548,6 +2575,7 @@ public class ManagedExecutorTest extends Arquillian {
         ManagedExecutor executor = ManagedExecutor.builder()
                 .maxAsync(1)
                 .propagated(Label.CONTEXT_NAME)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -176,6 +176,8 @@ public class ThreadContextTest extends Arquillian {
 
         ThreadContext threadContext = ThreadContext.builder()
                 .cleared(ThreadContext.TRANSACTION)
+                .unchanged()
+                .propagated(ThreadContext.ALL_REMAINING)
                 .build();
 
         Callable<String> taskWithNewTransaction = threadContext.contextualCallable(() -> {
@@ -264,6 +266,7 @@ public class ThreadContextTest extends Arquillian {
     public void contextualBiConsumerRunsWithContext() throws InterruptedException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -328,6 +331,8 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -388,6 +393,8 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext priorityContext = ThreadContext.builder()
                 .propagated(THREAD_PRIORITY)
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         int originalPriority = Thread.currentThread().getPriority();
@@ -430,6 +437,8 @@ public class ThreadContextTest extends Arquillian {
     public void contextualConsumerRunsWithContext() throws InterruptedException {
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -493,6 +502,8 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -553,6 +564,8 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext priorityAndBufferContext = ThreadContext.builder()
                 .propagated(THREAD_PRIORITY, Buffer.CONTEXT_NAME)
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         int originalPriority = Thread.currentThread().getPriority();
@@ -619,6 +632,7 @@ public class ThreadContextTest extends Arquillian {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
                 .unchanged(ThreadContext.APPLICATION)
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {
@@ -674,7 +688,8 @@ public class ThreadContextTest extends Arquillian {
     public void reuseThreadContextBuilder() throws Exception {
         ThreadContext.Builder builder = ThreadContext.builder()
                 .propagated()
-                .cleared(Buffer.CONTEXT_NAME, THREAD_PRIORITY);
+                .cleared(Buffer.CONTEXT_NAME, THREAD_PRIORITY)
+                .unchanged();
         
         ThreadContext clearingContext = builder.build();
         
@@ -799,6 +814,7 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
         ManagedExecutor bufferContextExecutor = ManagedExecutor.builder()
@@ -904,6 +920,7 @@ public class ThreadContextTest extends Arquillian {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
                 .cleared(ThreadContext.ALL_REMAINING)
+                .unchanged()
                 .build();
         ManagedExecutor labelContextExecutor = ManagedExecutor.builder()
                 .propagated(Label.CONTEXT_NAME)
@@ -1008,7 +1025,11 @@ public class ThreadContextTest extends Arquillian {
      */
     @Test
     public void withContextCaptureDependentStageForcedCompletion() throws ExecutionException, InterruptedException {
-        ThreadContext contextPropagator = ThreadContext.builder().build();
+        ThreadContext contextPropagator = ThreadContext.builder()
+                .propagated()
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
+                .build();
 
         CompletableFuture<String> stage1 = new CompletableFuture<String>();
         CompletableFuture<String> stage2 = contextPropagator.withContextCapture(stage1);
@@ -1039,10 +1060,12 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -1090,10 +1113,12 @@ public class ThreadContextTest extends Arquillian {
             throws ExecutionException, InterruptedException, TimeoutException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
         ThreadContext labelContext = ThreadContext.builder()
                 .propagated(Label.CONTEXT_NAME)
+                .unchanged()
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
@@ -1228,7 +1253,8 @@ public class ThreadContextTest extends Arquillian {
     public void currentContextExecutorRunsWithContext() throws InterruptedException, ExecutionException, TimeoutException {
         ThreadContext bufferContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
-                .cleared(Label.CONTEXT_NAME)
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
                 .build();
 
         try {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/BasicCDITest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/BasicCDITest.java
@@ -126,12 +126,7 @@ public class BasicCDITest extends Arquillian {
     }
 
     @Test
-    public void injectThreadContextWithoutConfig() {
-        bean.testInjectThreadContextNoConfig();
-    }
-
-    @Test
-    public void injectThreadContextWithEmptyConfig() throws Exception {
-        bean.testInjectThreadContextEmptyConfig();
+    public void injectThreadContextWithConfigThatPropagatesAllRemaining() throws Exception {
+        bean.testInjectThreadContextPropagateAllRemaining();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIContextTest.java
@@ -84,7 +84,9 @@ public class CDIContextTest extends Arquillian {
      */
     @Test
     public void testCDIMECtxPropagate() throws Exception {
-        ManagedExecutor propagateCDI = ManagedExecutor.builder().build();
+        ManagedExecutor propagateCDI = ManagedExecutor.builder().propagated(ThreadContext.CDI)
+                                                                .cleared(ThreadContext.ALL_REMAINING)
+                                                                .build();
         try {
             checkCDIPropagation(true, "testCDI_ME_Ctx_Propagate-REQUEST", propagateCDI, requestBean);
             checkCDIPropagation(true, "testCDI_ME_Ctx_Propagate-SESSION", propagateCDI, sessionBean);
@@ -130,7 +132,10 @@ public class CDIContextTest extends Arquillian {
      */
     @Test
     public void testCDITCCtxPropagate() throws Exception {
-        ThreadContext defaultTC = ThreadContext.builder().build();
+        ThreadContext defaultTC = ThreadContext.builder()
+                                               .propagated(ThreadContext.CDI)
+                                               .cleared(ThreadContext.ALL_REMAINING)
+                                               .build();
 
         requestBean.setState("testCDIContextPropagate-STATE2");
         Callable<String> getState = defaultTC.contextualCallable(() -> {

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/ManagedExecutorSharingBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/ManagedExecutorSharingBean.java
@@ -20,35 +20,27 @@ package org.eclipse.microprofile.concurrency.tck.cdi;
 
 import static org.testng.Assert.*;
 
-import java.util.Arrays;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
 import org.eclipse.microprofile.concurrent.NamedInstance;
+import org.eclipse.microprofile.concurrent.ThreadContext;
 
 @ApplicationScoped
 public class ManagedExecutorSharingBean {
+    @Inject
+    @ManagedExecutorConfig(propagated = ThreadContext.CDI, cleared = ThreadContext.ALL_REMAINING)
+    ManagedExecutor unnamedExec1;
 
     @Inject
-    ManagedExecutor defaultME;
-
-    @Inject
-    ManagedExecutor defaultME2;
-
-    @Inject
-    @ManagedExecutorConfig
-    ManagedExecutor defaultAnno1;
-
-    @Inject
-    @ManagedExecutorConfig
-    ManagedExecutor defaultAnno2;
+    @ManagedExecutorConfig(propagated = ThreadContext.CDI, cleared = ThreadContext.ALL_REMAINING)
+    ManagedExecutor unnamedExec2;
 
     @Inject
     @NamedInstance("A")
-    @ManagedExecutorConfig
+    @ManagedExecutorConfig(propagated = ThreadContext.CDI, cleared = ThreadContext.ALL_REMAINING)
     ManagedExecutor namedExecA1;
 
     @Inject
@@ -57,7 +49,7 @@ public class ManagedExecutorSharingBean {
 
     @Inject
     @NamedInstance("B")
-    @ManagedExecutorConfig
+    @ManagedExecutorConfig(propagated = ThreadContext.CDI, cleared = ThreadContext.ALL_REMAINING)
     ManagedExecutor namedExecB1;
 
     @Inject
@@ -65,18 +57,10 @@ public class ManagedExecutorSharingBean {
     ManagedExecutor namedExecB2;
 
     /**
-     * Verify the container creates a ManagedExecutor instance per unqualified ManagedExecutor injection point
-     */
-    public void testDefaultMEsDifferent() {
-        assertNotSame(defaultME.toString(), defaultME2.toString(),
-                "Default injection points \"@Inject ManagedExecutor exec;\" should get different instances");
-    }
-
-    /**
      * Verify the container creates a ManagedExecutor instance per unqualified injection point w/ config
      */
     public void testUnnamedConfigDifferent() {
-        assertNotSame(defaultAnno1.toString(), defaultAnno2.toString(),
+        assertNotSame(unnamedExec1.toString(), unnamedExec2.toString(),
                 "Default injection points with matching @ManagedExecutorConfig should get different instances");
     }
 
@@ -97,18 +81,4 @@ public class ManagedExecutorSharingBean {
         assertNotSame(namedExecA1.toString(), namedExecB1.toString(),
                 "Two injection points with different @NamedInstance values should get separate ManagedExecutor instances");
     }
-
-    public void testAllDefaultInjectionUnique() {
-        assertUnique(defaultME.toString(), defaultME2.toString(), defaultAnno1.toString(), defaultAnno2.toString());
-    }
-
-    private void assertUnique(String... executors) {
-        for (int i = 0; i < executors.length; i++) {
-            for (int j = i + 1; j < executors.length; j++) {
-                assertNotSame(executors[i], executors[j], "Expected all instances to be unique, but index " + i
-                        + " and " + j + " were the same: " + Arrays.toString(executors));
-            }
-        }
-    }
-
 }

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/ManagedExecutorSharingTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/ManagedExecutorSharingTest.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.ITestResult;
 import org.testng.annotations.Test;
 import org.testng.annotations.AfterMethod;
@@ -66,19 +65,8 @@ public class ManagedExecutorSharingTest extends Arquillian {
     }
     
     @Test
-    public void testDefaultMEsDifferent() {
-        Assert.assertNotNull(bean, "The CDIBean was not injected into this test");
-        bean.testDefaultMEsDifferent();
-    }
-
-    @Test
     public void testUnnamedConfigDifferent() {
         bean.testUnnamedConfigDifferent();
-    }
-
-    @Test
-    public void testAllDefaultInjectionUnique() {
-        bean.testAllDefaultInjectionUnique();
     }
 
     @Test

--- a/tck/src/main/resources/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/META-INF/microprofile-config.properties
@@ -18,6 +18,15 @@
 # under the License.
 #
 
+ManagedExecutor/maxAsync=1
+ManagedExecutor/maxQueued=4
+ManagedExecutor/propagated=Label,ThreadPriority
+ManagedExecutor/cleared=Remaining
+
+ThreadContext/cleared=Buffer
+ThreadContext/propagated=
+ThreadContext/unchanged=Remaining
+
 org.eclipse.microprofile.concurrency.tck.MPConfigBean/createExecutor/1/ManagedExecutorConfig/maxAsync=1
 
 org.eclipse.microprofile.concurrency.tck.MPConfigBean/createThreadContext/3/ThreadContextConfig/propagated=Label


### PR DESCRIPTION
This pull partially implements the agreed upon resolution from issue #124, in that it removes the configuration defaults for context propagation and updates all tests and doc accordingly.  I've also added the definition of how to use MP Config to specify defaults for config attributes.