### PR TITLE
document exceptions raised when optional transaction context is not supported

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ThreadContextProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/concurrent/spi/ThreadContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -59,9 +59,16 @@ public interface ThreadContextProvider {
      *        Thread context providers that don't supply or use execution properties
      *        can ignore this parameter.
      * @return immutable snapshot of the provided type of context, captured from the
-     *         current thread. NULL must be returned if the thread context provider
-     *         does not support capturing context from the current thread and
-     *         propagating it to other threads.
+     *         current thread.
+     * @throws IllegalStateException the {@link org.eclipse.microprofile.concurrent.ThreadContext#TRANSACTION Transaction}
+     *         context provider may raise this exception
+     *         if it chooses not to support the optional capability of propagating Transaction
+     *         context across threads. This exception flows back to the application when the
+     *         application invokes an operation that captures context, such as
+     *         {@link org.eclipse.microprofile.concurrent.ManagedExecutor#runAsync(Runnable) runAsync},
+     *         {@link org.eclipse.microprofile.concurrent.ThreadContext#withContextCapture(java.util.concurrent.CompletableFuture)
+     *         withContextCapture}, and
+     *         {@link org.eclipse.microprofile.concurrent.ThreadContext#contextualFunction(java.util.function.Function) contextualFunction}.
      */
     ThreadContextSnapshot currentContext(Map<String, String> props);
 

--- a/spec/src/main/asciidoc/microprofile-concurrency.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-concurrency.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -44,6 +44,8 @@ include::builders.asciidoc[]
 include::cdi.asciidoc[]
 
 include::mpconfig.asciidoc[]
+
+include::txcontext.asciidoc[]
 
 include::examples.asciidoc[]
 

--- a/spec/src/main/asciidoc/txcontext.asciidoc
+++ b/spec/src/main/asciidoc/txcontext.asciidoc
@@ -166,7 +166,9 @@ try {
 
 === Propagation of Active Transactions for Parallel Use
 
-An implementation that supports the optional behavior of propagating active transactions for use on multiple threads in parallel does not raise `IllegalStateException` at any point. As always, the application is responsible for following best practices to ensure transactions are properly resolved and transactional resources are properly cleaned up under all possible outcomes.
+An implementation that supports the optional behavior of propagating active transactions for use on multiple threads in parallel may choose whether or not to support commit and rollback operations from dependent stage actions. If unsupported, these operations raise `SystemException` when invoked from a separate completion stage action. As always, the application is responsible for following best practices to ensure transactions are properly resolved and transactional resources are properly cleaned up under all possible outcomes.
+
+Here is an example of committing the transaction in a dependent stage action,
 
 [source, java]
 ----
@@ -178,9 +180,9 @@ try {
                    .whenComplete((result, failure) -> {
         try {
             if (failure == null && tx.getStatus() == Status.STATUS_ACTIVE)
-                tx.commit();
+                tx.commit();   // <-- raises SystemException if unsupported within dependent stage
             else
-                tx.rollback();
+                tx.rollback(); // <-- raises SystemException if unsupported within dependent stage
         } catch (Exception x) {
             if (failure == null)
                 throw new CompletionException(x);
@@ -189,5 +191,23 @@ try {
 } finally {
     // vendor-specific means required to obtain TransactionManager instance
     transactionManager.suspend();
+}
+----
+
+Here is an example of committing the transaction from the main thread,
+
+[source, java]
+----
+tx.begin();
+try {
+    stage1 = executor.runAsync(action1);
+    stage2 = executor.runAsync(action2);
+    stage3 = CompletableFuture.allOf(stage1, stage2);
+    stage3.join();
+} finally {
+    if (tx.getStatus() == Status.STATUS_ACTIVE && !stage3.isCompletedExceptionally())
+        tx.commit();
+    else
+        tx.rollback();
 }
 ----

--- a/spec/src/main/asciidoc/txcontext.asciidoc
+++ b/spec/src/main/asciidoc/txcontext.asciidoc
@@ -1,0 +1,193 @@
+//
+// Copyright (c) 2019 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[concurrencytxcontext]]
+== Transaction Context
+
+Implementations of MicroProfile Concurrency are allowed to provide varying degrees of support for transaction context.
+
+This varies from not supporting transactions at all, to supporting the clearing of transaction context only, to supporting propagation of transactions for serial, or even parallel use.  The `ThreadContextProvider` for transaction context raises exceptions that are defined by the specification to indicate lack of support for the various optional aspects of transaction context propagation.
+
+=== No Support for Transactions
+
+The `ManagedExecutor` and `ThreadContext` builders are allowed to raise `IllegalStateException` from the `build` method when a builder is configured to propagate transaction context but transactions are not supported (no provider of transaction context is available). This follows the general pattern defined by the `build` method JavaDoc concerning unavailable context types.
+
+[source, java]
+----
+executor = ManagedExecutor.builder()
+                          .propagated(ThreadContext.TRANSACTION)
+                          .cleared(ThreadContext.ALL_REMAINING)
+                          .build(); // <-- raises IllegalStateException
+----
+
+=== Propagation of the Absence of a Transaction, but not of Active Transactions
+
+It can be useful to propagate that a completion stage action does not run under a transaction in order to guarantee deterministic behavior and allow the action to manage its own transactional work. This is important in being able to write applications that reliably access completion stage results from within a transaction without risking that the action might run as part of the transaction. For example,
+
+[source, java]
+----
+executor = ManagedExecutor.builder()
+           .propagated(ThreadContext.TRANSACTION, ThreadContext.APPLICATION)
+           .cleared(ThreadContext.ALL_REMAINING)
+           .build();
+
+// propagates the absence of a transaction,
+// allowing the action to start its own transaction
+stage1 = executor.supplyAsync(supplier);
+stage2 = stage1.thenApply(u -> {
+    try {
+        DataSource ds = InitialContext.doLookup("java:comp/env/ds1");
+        UserTransaction tx = InitialContext.doLookup("java:comp/UserTransaction");
+        tx.begin();
+        try (Connection con = ds.getConnection()) {
+            return u + con.createStatement().executeUpdate(sql);
+        } finally {
+            tx.commit();
+        }
+    } catch (Exception x) {
+        throw new CompletionException(x);
+    }
+});
+
+tx.begin();
+... do transactional work here
+
+updateCount = stage2.join(); // <-- stage2's action is guaranteed to never
+                             //     run under this transaction because absence
+                             //     of a transaction is propagated to it
+
+... more transactional work
+----
+
+It should be noted that cleared, rather than propagated, transaction context can accomplish the same.
+
+A `ThreadContextProvider` that supports propagation of the absence of a transaction, but not propagation of an active transaction is allowed to raise `IllegalStateException` from its `currentContext` method. The exception flows back to the application on operations such as `managedExecutor.supplyAsync(supplier)`, `threadContext.withContextCapture`, or `threadContext.contextualFunction`, indicating the restriction against propagating active transactions. The `IllegalStateException` should have a meaningful message making it clear to the user that lack of support for the propagation of active transactions is the cause of the error.
+
+For example, the application can expect to see `IllegalStateException` here if the optional behavior of propagating active transactions to other threads is not supported,
+
+[source, java]
+----
+tx.begin();
+stage = executor.runAsync(action); // <-- raises IllegalStateException
+...
+----
+
+=== Propagation of Active Transactions for Serial Use, but not Parallel
+
+Some transaction managers and transactional resources may allow for propagation of an active transaction to multiple threads serially, with the limitation that the transaction is active on at most one thread at any given time.
+
+For example,
+
+[source, java]
+----
+executor = ManagedExecutor.builder()
+           .propagated(ThreadContext.TRANSACTION)
+           .build();
+
+// Allowed because it limits the transaction to serial use
+stage1 = executor.newIncompleteFuture();
+tx.begin();
+try {
+    stage3 = stage1.thenApply(updateCount -> {
+        try (Connection con = dataSource.getConnection()) {
+            return updateCount + con.createStatement().executeUpdate(sql2);
+        } catch (SQLException x) {
+            throw new CompletionException(x);
+        }
+    }).thenApply(updateCount -> {
+        try (Connection con = dataSource.getConnection()) {
+            return updateCount + con.createStatement().executeUpdate(sql3);
+        } catch (SQLException x) {
+            throw new CompletionException(x);
+        }
+    }).whenComplete((result, failure) -> {
+        try {
+            if (failure == null && tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
+        } catch (Exception x) {
+            if (failure == null)
+                throw new CompletionException(x);
+        }
+    });
+} finally {
+    // vendor-specific means required to obtain TransactionManager instance
+    transactionManager.suspend();
+}
+
+// ... possibly on another thread
+stage1.complete(initialCount);
+----
+
+A 'ThreadContextProvider' that supports serial use of a propagated transaction, but not parallel use, is allowed to raise `IllegalStateException` upon attempts to associate a JTA transaction to a second thread when the JTA transaction is already active on another thread. The transaction context provider raises `IllegalStateException` upon `ThreadContextSnapshot.begin`, which exceptionally completes the action or task without running it. The `IllegalStateException` should have a meaningful message making it clear to the user that lack of support for the propagation of active transactions for parallel use across multiple threads is the cause of the error.
+
+The application sees the error when requesting the result of the corresponding stage. For example,
+
+[source, java]
+----
+tx.begin();
+try {
+    stage = executor.supplyAsync(() -> {
+        try (Connection con = dataSource.getConnection()) {
+            return con.createStatement().executeUpdate(sql1);
+        } catch (SQLException) {
+            throw new CompletionException(x);
+        }
+    });
+
+    try (Connection con = dataSource.getConnection()) {
+        con.createStatement().executeUpdate(sql2);
+    });
+
+    stage.join(); // <-- raises CompletionException with a chained
+                  //     IllegalStateException indicating lack of support
+                  //     for propagating an active transaction to multiple
+                  //     threads
+
+    tx.commit();
+} catch (Exception x) {
+    tx.rollback();
+    ...
+----
+
+=== Propagation of Active Transactions for Parallel Use
+
+An implementation that supports the optional behavior of propagating active transactions for use on multiple threads in parallel does not raise `IllegalStateException` at any point. As always, the application is responsible for following best practices to ensure transactions are properly resolved and transactional resources are properly cleaned up under all possible outcomes.
+
+[source, java]
+----
+tx.begin();
+try {
+    stage1 = executor.runAsync(action1);
+    stage2 = executor.runAsync(action2);
+    stage3 = stage1.runAfterBoth(stage2, (u,v) -> action3)
+                   .whenComplete((result, failure) -> {
+        try {
+            if (failure == null && tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
+        } catch (Exception x) {
+            if (failure == null)
+                throw new CompletionException(x);
+        }
+    });
+} finally {
+    // vendor-specific means required to obtain TransactionManager instance
+    transactionManager.suspend();
+}
+----

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ManagedExecutorTest.java
@@ -1617,12 +1617,26 @@ public class ManagedExecutorTest extends Arquillian {
                     }
                 });
             }
-            catch (UnsupportedOperationException x) {
+            catch (IllegalStateException x) {
                 System.out.println("Skipping portion of test propagateTransactionContextJTA. Propagation of active transaction is not supported.");
                 return;
             }
 
-            Assert.assertEquals(stage2.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS), "SUCCESS2");
+            String result;
+            try {
+                result = stage2.get(MAX_WAIT_NS, TimeUnit.NANOSECONDS);
+            }
+            catch (ExecutionException x) {
+                if (x.getCause() instanceof IllegalStateException) {
+                    System.out.println("Skipping portion of test propagateTransactionContextJTA. " +
+                                       "Propagation of active transaction to multiple threads in parallel is not supported.");
+                    return;
+                }
+                else {
+                    throw x;
+                }
+            }
+            Assert.assertEquals(result, "SUCCESS2");
         }
         finally {
             commit.invoke(tx);


### PR DESCRIPTION
Add documentation of where exceptions can be raised and which exceptions to raise in various places where transaction context propagation (which is optional) can be rejected.  Update TCK tests to allow for these exceptions.

fixes #137

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>