### PR TITLE
Correct some TCKs to fully define TC now that there are no defaults.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/ThreadContextTest.java
@@ -212,6 +212,7 @@ public class ThreadContextTest extends Arquillian {
         ThreadContext threadContext = ThreadContext.builder()
                 .propagated(Buffer.CONTEXT_NAME)
                 .unchanged(Label.CONTEXT_NAME)
+                .cleared()
                 .build();
         
         int originalPriority = Thread.currentThread().getPriority();     

--- a/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/concurrency/tck/cdi/CDIContextTest.java
@@ -135,6 +135,7 @@ public class CDIContextTest extends Arquillian {
         ThreadContext defaultTC = ThreadContext.builder()
                                                .propagated(ThreadContext.CDI)
                                                .cleared(ThreadContext.ALL_REMAINING)
+                                               .unchanged()
                                                .build();
 
         requestBean.setState("testCDIContextPropagate-STATE2");
@@ -154,6 +155,7 @@ public class CDIContextTest extends Arquillian {
         ThreadContext clearAllCtx = ThreadContext.builder()
                         .propagated() // propagate nothing
                         .cleared(ThreadContext.ALL_REMAINING)
+                        .unchanged()
                         .build();
 
         requestBean.setState("testCDIThreadCtxClear-STATE1");


### PR DESCRIPTION
Found these three tests that do not define all aspects of `ThreadContext` which is wrong now that we do not have any defaults.